### PR TITLE
Refactor ChalkboardFunction to be function-based instead of string-based

### DIFF
--- a/src/Chalkboard-calc.ts
+++ b/src/Chalkboard-calc.ts
@@ -10,108 +10,115 @@ namespace Chalkboard {
      */
     export namespace calc {
         /**
-         * Calculates the autocorrelation of an explicit function at a value.
+         * Calculates the autocorrelation of a function at a value.
          * @param {ChalkboardFunction} func - The function
          * @param {number} val - The value
          * @returns {number}
          */
         export const autocorrelation = (func: ChalkboardFunction, val: number): number => {
+            if (func.field !== "real" || func.type !== "scalar2d") {
+                throw new TypeError("Chalkboard.calc.autocorrelation: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'scalar2d'.");
+            }
             return Chalkboard.calc.correlation(func, func, val);
         };
 
         /**
-         * Calculates the binormal vector of a parametric curve function at a value.
+         * Calculates the binormal vector of a parametric curve at a value.
          * @param {ChalkboardFunction} func - The function
          * @param {number} val - The value
          * @returns {ChalkboardVector}
          */
         export const binormal = (func: ChalkboardFunction, val: number): ChalkboardVector => {
-            if (func.type === "curv") {
-                if (func.definition.length === 2) {
-                    return Chalkboard.vect.cross(Chalkboard.calc.tangent(func, val), Chalkboard.calc.normal(func, val));
-                } else {
-                    return Chalkboard.vect.cross(Chalkboard.calc.tangent(func, val), Chalkboard.calc.normal(func, val));
-                }
-            } else {
-                throw new TypeError('Parameter "func" must be of type "ChalkboardFunction" with a "type" property of "curv".');
+            if (func.field !== "real") {
+                throw new TypeError("Chalkboard.calc.binormal: Property 'field' of 'func' must be 'real'.");
             }
+            if (func.type.startsWith("curve")) {
+                return Chalkboard.vect.cross(Chalkboard.calc.tangent(func, val), Chalkboard.calc.normal(func, val));
+            }
+            throw new TypeError("Chalkboard.real.binormal: Property 'type' of 'func' must be 'curve2d' or 'curve3d'.");
         };
 
         /**
-         * Calculates the convolution of two explicit functions at a value.
+         * Calculates the convolution of two functions at a value.
          * @param {ChalkboardFunction} func1 - The first function
          * @param {ChalkboardFunction} func2 - The second function
          * @param {number} val - The value
          * @returns {number}
          */
         export const convolution = (func1: ChalkboardFunction, func2: ChalkboardFunction, val: number): number => {
-            return Chalkboard.calc.fxdx(Chalkboard.real.define("(" + func1.definition + ") * (" + (func2.definition as string).replace(/x/g, "(" + val + " - x)") + ")"), -100, 100) as number;
+            if (func1.field !== "real" || func2.field !== "real" || func1.type !== "scalar2d" || func2.type !== "scalar2d") {
+                throw new TypeError("Chalkboard.calc.convolution: Properties 'field' of 'func1' and 'func2' must be 'real' and properties 'type' of 'func1' and 'func2' must be 'scalar2d'.");
+            }
+            const f1 = func1.rule as (x: number) => number;
+            const f2 = func2.rule as (x: number) => number;
+            const g = (x: number): number => f1(x) * f2(val - x);
+            return Chalkboard.calc.fxdx(Chalkboard.real.define(g), -100, 100) as number;
         };
 
         /**
-         * Calculates the cross-correlation of two explicit functions at a value.
+         * Calculates the cross-correlation of two functions at a value.
          * @param {ChalkboardFunction} func1 - The first function
          * @param {ChalkboardFunction} func2 - The second function
          * @param {number} val - The value
          * @returns {number}
          */
         export const correlation = (func1: ChalkboardFunction, func2: ChalkboardFunction, val: number): number => {
-            return Chalkboard.calc.fxdx(Chalkboard.real.define("(" + func1.definition + ") * (" + (func2.definition as string).replace(/x/g, "(" + val + " + x)") + ")"), -100, 100) as number;
+            if (func1.field !== "real" || func2.field !== "real" || func1.type !== "scalar2d" || func2.type !== "scalar2d") {
+                throw new TypeError("Chalkboard.calc.correlation: Properties 'field' of 'func1' and 'func2' must be 'real' and properties 'type' of 'func1' and 'func2' must be 'scalar2d'.");
+            }
+            const f1 = func1.rule as (x: number) => number; 
+            const f2 = func2.rule as (x: number) => number;
+            const g = (x: number): number => f1(x) * f2(val + x);
+            return Chalkboard.calc.fxdx(Chalkboard.real.define(g), -100, 100) as number;
         };
 
         /**
          * Calculates the curl of a 2D or 3D vector field at a vector.
-         * @param {ChalkboardVectorField} vectfield - The vector field
+         * @param {ChalkboardFunction} vectfield - The vector field
          * @param {ChalkboardVector} vect - The vector
          * @returns {ChalkboardVector}
          */
-        export const curl = (vectfield: ChalkboardVectorField, vect: ChalkboardVector): ChalkboardVector => {
-            vect = vect as { x: number, y: number, z?: number, w?: number };
-            const h = 0.000000001;
-            if (Chalkboard.vect.dimension(vectfield) === 2 && typeof vect.x === "number" && typeof vect.y === "number" && typeof vect.z === "undefined" && typeof vect.w === "undefined") {
-                const p = Chalkboard.real.parse("(x, y) => " + vectfield.p),
-                    q = Chalkboard.real.parse("(x, y) => " + vectfield.q);
-                const dpdy = (p(vect.x, vect.y + h) - p(vect.x, vect.y)) / h,
-                    dqdx = (q(vect.x + h, vect.y) - q(vect.x, vect.y)) / h;
-                return Chalkboard.vect.init(0, 0, dqdx - dpdy);
-            } else if (Chalkboard.vect.dimension(vectfield) === 3 && typeof vect.x === "number" && typeof vect.y === "number" && typeof vect.z === "number" && typeof vect.w === "undefined") {
-                const p = Chalkboard.real.parse("(x, y, z) => " + vectfield.p),
-                    q = Chalkboard.real.parse("(x, y, z) => " + vectfield.q),
-                    r = Chalkboard.real.parse("(x, y, z) => " + vectfield.r);
-                const dpdy = (p(vect.x, vect.y + h, vect.z) - p(vect.x, vect.y, vect.z)) / h,
-                    dpdz = (p(vect.x, vect.y, vect.z + h) - p(vect.x, vect.y, vect.z)) / h,
-                    dqdx = (q(vect.x + h, vect.y, vect.z) - q(vect.x, vect.y, vect.z)) / h,
-                    dqdz = (q(vect.x, vect.y, vect.z + h) - q(vect.x, vect.y, vect.z)) / h,
-                    drdx = (r(vect.x + h, vect.y, vect.z) - r(vect.x, vect.y, vect.z)) / h,
-                    drdy = (r(vect.x, vect.y + h, vect.z) - r(vect.x, vect.y, vect.z)) / h;
-                return Chalkboard.vect.init(drdy - dqdz, dpdz - drdx, dqdx - dpdy);
-            } else {
-                throw new TypeError('Parameter "vectfield" must be of type "ChalkboardVectorField" with 2 or 3 dimensions.');
+        export const curl = (vectfield: ChalkboardFunction, vect: ChalkboardVector): ChalkboardVector => {
+            if (vectfield.field !== "real") {
+                throw new TypeError("Chalkboard.calc.curl: Property 'field' of 'vectfield' must be 'real'.");
             }
+            const f = vectfield.rule as ((...x: number[]) => number)[];
+            const v = vect as { x: number, y: number, z?: number, w?: number };
+            const h = 0.000000001;
+            if (vectfield.type === "vector2d") {
+                const dpdy = (f[0](v.x, v.y + h) - f[0](v.x, v.y)) / h;
+                const dqdx = (f[1](v.x + h, v.y) - f[1](v.x, v.y)) / h;
+                return Chalkboard.vect.init(0, 0, dqdx - dpdy);
+            } else if (vectfield.type === "vector3d") {
+                const dpdy = (f[0](v.x, v.y + h, v.z!) - f[0](v.x, v.y, v.z!)) / h;
+                const dpdz = (f[0](v.x, v.y, v.z! + h) - f[0](v.x, v.y, v.z!)) / h;
+                const dqdx = (f[1](v.x + h, v.y, v.z!) - f[1](v.x, v.y, v.z!)) / h;
+                const dqdz = (f[1](v.x, v.y, v.z! + h) - f[1](v.x, v.y, v.z!)) / h;
+                const drdx = (f[2](v.x + h, v.y, v.z!) - f[2](v.x, v.y, v.z!)) / h;
+                const drdy = (f[2](v.x, v.y + h, v.z!) - f[2](v.x, v.y, v.z!)) / h;
+                return Chalkboard.vect.init(drdy - dqdz, dpdz - drdx, dqdx - dpdy);
+            }
+            throw new TypeError("Chalkboard.real.curl: Property 'type' of 'vectfield' must be 'vector2d' or 'vector3d'.");
         };
 
         /**
-         * Calculates the curvature of a parametric curve function at a value.
+         * Calculates the curvature of a parametric curve at a value.
          * @param {ChalkboardFunction} func - The function
          * @param {number} val - The value
          * @returns {number}
          */
         export const curvature = (func: ChalkboardFunction, val: number): number => {
-            if (func.type === "curv") {
-                if (func.definition.length === 2) {
-                    const d = Chalkboard.calc.dfdx(func, val) as ChalkboardVector as { x: number, y: number, z?: number, w?: number },
-                        d2 = Chalkboard.calc.d2fdx2(func, val) as ChalkboardVector as { x: number, y: number, z?: number, w?: number };
-                    const dxdt = d.x,
-                        dydt = d.y,
-                        d2xdt2 = d2.x,
-                        d2ydt2 = d2.y;
-                    return Math.abs(dxdt * d2ydt2 - dydt * d2xdt2) / Math.sqrt((dxdt * dxdt + dydt * dydt) * (dxdt * dxdt + dydt * dydt) * (dxdt * dxdt + dydt * dydt));
-                } else {
-                    return Chalkboard.vect.mag(Chalkboard.calc.normal(func, val)) / Chalkboard.vect.mag(Chalkboard.calc.dfdx(func, val) as ChalkboardVector);
-                }
-            } else {
-                throw new TypeError('Parameter "func" must be of type "ChalkboardFunction" with a "type" property of "curv".');
+            if (func.field !== "real") {
+                throw new TypeError("Chalkboard.calc.curvature: Property 'field' of 'func' must be 'real'.");
             }
+            if (func.type === "curve2d") {
+                const d = Chalkboard.calc.dfdx(func, val) as ChalkboardVector as { x: number, y: number, z?: number, w?: number };
+                const d2 = Chalkboard.calc.d2fdx2(func, val) as ChalkboardVector as { x: number, y: number, z?: number, w?: number };
+                return Math.abs(d.x * d2.y - d.y * d2.x) / Math.sqrt((d.x * d.x + d.y * d.y) * (d.x * d.x + d.y * d.y) * (d.x * d.x + d.y * d.y));
+            } else if (func.type === "curve3d") {
+                return Chalkboard.vect.mag(Chalkboard.calc.normal(func, val)) / Chalkboard.vect.mag(Chalkboard.calc.dfdx(func, val) as ChalkboardVector);
+            }
+            throw new TypeError("Chalkboard.real.curvature: Property 'type' of 'func' must be 'curve2d' or 'curve3d'.");
         };
 
         /**
@@ -122,77 +129,63 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const dfdv = (func: ChalkboardFunction, vectpos: ChalkboardVector, vectdir: ChalkboardVector): number => {
-            if (func.type === "mult") {
-                return Chalkboard.vect.dot(Chalkboard.calc.grad(func, vectpos) as ChalkboardVector, Chalkboard.vect.normalize(vectdir));
-            } else {
-                throw new TypeError('Parameter "func" must be of type "ChalkboardFunction" with a "type" property of "mult".');
+            if (func.field !== "real") {
+                throw new TypeError('Chalkboard.calc.dfdv: Property "field" of "func" must be "real".');
             }
+            if (func.type === "scalar3d") {
+                const grad = Chalkboard.calc.grad(func, vectpos) as ChalkboardVector as { x: number, y: number, z?: number, w?: number };
+                const dir = Chalkboard.vect.normalize(vectdir);
+                return Chalkboard.vect.dot(grad, dir);
+            }
+            throw new TypeError("Chalkboard.real.dfdv: Property 'type' of 'func' must be 'scalar3d'.");
         };
 
         /**
-         * Calculates the first-order derivative of an explicit, inverse, polar, or parametric curve function at a value.
+         * Calculates the first-order derivative of a 2D scalar or parametric function at a value.
          * @param {ChalkboardFunction} func - The function
          * @param {number} val - The value
          * @returns {number | ChalkboardVector}
          */
         export const dfdx = (func: ChalkboardFunction, val: number): number | ChalkboardVector => {
-            const h = 0.000000001;
-            if (func.type === "expl") {
-                const f = Chalkboard.real.parse("x => " + func.definition);
-                return (f(val + h) - f(val)) / h;
-            } else if (func.type === "inve") {
-                const f = Chalkboard.real.parse("y => " + func.definition);
-                return (f(val + h) - f(val)) / h;
-            } else if (func.type === "pola") {
-                const r = Chalkboard.real.parse("O => " + func.definition);
-                return (r(val + h) - r(val)) / h;
-            } else if (func.type === "curv") {
-                if (func.definition.length === 2) {
-                    const x = Chalkboard.real.parse("t => " + func.definition[0]),
-                        y = Chalkboard.real.parse("t => " + func.definition[1]);
-                    return Chalkboard.vect.init((x(val + h) - x(val)) / h, (y(val + h) - y(val)) / h);
-                } else {
-                    const x = Chalkboard.real.parse("t => " + func.definition[0]),
-                        y = Chalkboard.real.parse("t => " + func.definition[1]),
-                        z = Chalkboard.real.parse("t => " + func.definition[2]);
-                    return Chalkboard.vect.init((x(val + h) - x(val)) / h, (y(val + h) - y(val)) / h, (z(val + h) - z(val)) / h);
-                }
-            } else {
-                throw new TypeError('Parameter "func" must be of type "ChalkboardFunction" with a "type" property of "expl", "inve", "pola", or "curv".');
+            if (func.field !== "real") {
+                throw new TypeError("Chalkboard.calc.dfdx: Property 'field' of 'func' must be 'real'.");
             }
+            const h = 0.000000001;
+            if (func.type === "scalar2d") {
+                const f = func.rule as (x: number) => number;
+                return (f(val + h) - f(val)) / h;
+            } else if (func.type === "curve2d") {
+                const f = func.rule as ((t: number) => number)[];
+                return Chalkboard.vect.init((f[0](val + h) - f[0](val)) / h, (f[1](val + h) - f[1](val)) / h);
+            } else if (func.type === "curve3d") {
+                const f = func.rule as ((t: number) => number)[];
+                return Chalkboard.vect.init((f[0](val + h) - f[0](val)) / h, (f[1](val + h) - f[1](val)) / h, (f[2](val + h) - f[2](val)) / h);
+            }
+            throw new TypeError("Chalkboard.real.dfdx: Property 'type' of 'func' must be 'scalar2d', 'curve2d', or 'curve3d'.");
         };
 
         /**
-         * Calculates the second-order derivative of an explicit, inverse, polar, or parametric curve function at a value.
+         * Calculates the second-order derivative of a 2D scalar or parametric function at a value.
          * @param {ChalkboardFunction} func - The function
          * @param {number} val - The value
          * @returns {number | ChalkboardVector}
          */
         export const d2fdx2 = (func: ChalkboardFunction, val: number): number | ChalkboardVector => {
-            const h = 0.00001;
-            if (func.type === "expl") {
-                const f = Chalkboard.real.parse("x => " + func.definition);
-                return (f(val + h) - 2 * f(val) + f(val - h)) / (h * h);
-            } else if (func.type === "inve") {
-                const f = Chalkboard.real.parse("y => " + func.definition);
-                return (f(val + h) - 2 * f(val) + f(val - h)) / (h * h);
-            } else if (func.type === "pola") {
-                const r = Chalkboard.real.parse("O => " + func.definition);
-                return (r(val + h) - 2 * r(val) + r(val - h)) / (h * h);
-            } else if (func.type === "curv") {
-                if (func.definition.length === 2) {
-                    const x = Chalkboard.real.parse("t => " + func.definition[0]),
-                        y = Chalkboard.real.parse("t => " + func.definition[1]);
-                    return Chalkboard.vect.init((x(val + h) - 2 * x(val) + x(val - h)) / (h * h), (y(val + h) - 2 * y(val) + y(val - h)) / (h * h));
-                } else {
-                    const x = Chalkboard.real.parse("t => " + func.definition[0]),
-                        y = Chalkboard.real.parse("t => " + func.definition[1]),
-                        z = Chalkboard.real.parse("t => " + func.definition[2]);
-                    return Chalkboard.vect.init((x(val + h) - 2 * x(val) + x(val - h)) / (h * h), (y(val + h) - 2 * y(val) + y(val - h)) / (h * h), (z(val + h) - 2 * z(val) + z(val - h)) / (h * h));
-                }
-            } else {
-                throw new TypeError('Parameter "func" must be of type "ChalkboardFunction" with a "type" property of "expl", "inve", "pola", or "curv".');
+            if (func.field !== "real") {
+                throw new TypeError("Chalkboard.calc.d2fdx2: Property 'field' of 'func' must be 'real'.");
             }
+            const h = 0.00001;
+            if (func.type === "scalar2d") {
+                const f = func.rule as (x: number) => number;
+                return (f(val + h) - 2 * f(val) + f(val - h)) / (h * h);
+            } else if (func.type === "curve2d") {
+                const f = func.rule as ((t: number) => number)[];
+                return Chalkboard.vect.init((f[0](val + h) - 2 * f[0](val) + f[0](val - h)) / (h * h), (f[1](val + h) - 2 * f[1](val) + f[1](val - h)) / (h * h));
+            } else if (func.type === "curve3d") {
+                const f = func.rule as ((t: number) => number)[];
+                return Chalkboard.vect.init((f[0](val + h) - 2 * f[0](val) + f[0](val - h)) / (h * h), (f[1](val + h) - 2 * f[1](val) + f[1](val - h)) / (h * h), (f[2](val + h) - 2 * f[2](val) + f[2](val - h)) / (h * h));
+            }
+            throw new TypeError("Chalkboard.real.d2fdx2: Property 'type' of 'func' must be 'scalar2d', 'curve2d', or 'curve3d'.");
         };
 
         /**
@@ -202,18 +195,19 @@ namespace Chalkboard {
          * @returns {ChalkboardComplex[]}
          */
         export const dfdz = (func: ChalkboardFunction, comp: ChalkboardComplex): [ChalkboardComplex, ChalkboardComplex] => {
-            const h = 0.000000001;
-            if (func.type === "comp") {
-                const u = Chalkboard.comp.parse("(a, b) => " + func.definition[0]),
-                    v = Chalkboard.comp.parse("(a, b) => " + func.definition[1]);
-                const duda = (u(comp.a + h, comp.b) - u(comp.a, comp.b)) / h,
-                    dudb = (u(comp.a, comp.b + h) - u(comp.a, comp.b)) / h,
-                    dvda = (v(comp.a + h, comp.b) - v(comp.a, comp.b)) / h,
-                    dvdb = (v(comp.a, comp.b + h) - v(comp.a, comp.b)) / h;
-                return [Chalkboard.comp.init(duda, dvda), Chalkboard.comp.init(dudb, dvdb)];
-            } else {
-                throw new TypeError('Parameter "func" must be of type "ChalkboardFunction" with a "type" property of "comp".');
+            if (func.field !== "comp") {
+                throw new TypeError("Chalkboard.calc.dfdz: Property 'field' of 'func' must be 'comp'.");
             }
+            const h = 0.000000001;
+            if (func.type === "scalar3d") {
+                const f = func.rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const duda = (f[0](comp.a + h, comp.b) - f[0](comp.a, comp.b)) / h;
+                const dudb = (f[0](comp.a, comp.b + h) - f[0](comp.a, comp.b)) / h;
+                const dvda = (f[1](comp.a + h, comp.b) - f[1](comp.a, comp.b)) / h;
+                const dvdb = (f[1](comp.a, comp.b + h) - f[1](comp.a, comp.b)) / h;
+                return [Chalkboard.comp.init(duda, dvda), Chalkboard.comp.init(dudb, dvdb)];
+            }
+            throw new TypeError("Chalkboard.real.dfdz: Property 'type' of 'func' must be 'scalar3d'.");
         };
 
         /**
@@ -223,78 +217,71 @@ namespace Chalkboard {
          * @returns {ChalkboardComplex[]}
          */
         export const d2fdz2 = (func: ChalkboardFunction, comp: ChalkboardComplex): [ChalkboardComplex, ChalkboardComplex] => {
-            const h = 0.00001;
-            if (func.type === "comp") {
-                const u = Chalkboard.comp.parse("(a, b) => " + func.definition[0]),
-                    v = Chalkboard.comp.parse("(a, b) => " + func.definition[1]);
-                const d2uda2 = (u(comp.a + h, comp.b) - 2 * u(comp.a, comp.b) + u(comp.a - h, comp.b)) / (h * h),
-                    d2udb2 = (u(comp.a, comp.b + h) - 2 * u(comp.a, comp.b) + u(comp.a, comp.b - h)) / (h * h),
-                    d2vda2 = (v(comp.a + h, comp.b) - 2 * v(comp.a, comp.b) + v(comp.a - h, comp.b)) / (h * h),
-                    d2vdb2 = (v(comp.a, comp.b + h) - 2 * v(comp.a, comp.b) + v(comp.a, comp.b - h)) / (h * h);
-                return [Chalkboard.comp.init(d2uda2, d2vda2), Chalkboard.comp.init(d2udb2, d2vdb2)];
-            } else {
-                throw new TypeError('Parameter "func" must be of type "ChalkboardFunction" with a "type" property of "comp".');
+            if (func.field !== "comp") {
+                throw new TypeError("Chalkboard.calc.d2fdz2: Property 'field' of 'func' must be 'comp'.");
             }
+            const h = 0.00001;
+            if (func.type === "scalar3d") {
+                const f = func.rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const d2uda2 = (f[0](comp.a + h, comp.b) - 2 * f[0](comp.a, comp.b) + f[0](comp.a - h, comp.b)) / (h * h);
+                const d2udb2 = (f[0](comp.a, comp.b + h) - 2 * f[0](comp.a, comp.b) + f[0](comp.a, comp.b - h)) / (h * h);
+                const d2vda2 = (f[1](comp.a + h, comp.b) - 2 * f[1](comp.a, comp.b) + f[1](comp.a - h, comp.b)) / (h * h);
+                const d2vdb2 = (f[1](comp.a, comp.b + h) - 2 * f[1](comp.a, comp.b) + f[1](comp.a, comp.b - h)) / (h * h);
+                return [Chalkboard.comp.init(d2uda2, d2vda2), Chalkboard.comp.init(d2udb2, d2vdb2)];
+            }
+            throw new TypeError("Chalkboard.real.d2fdz2: Property 'type' of 'func' must be 'scalar3d'.");
         };
 
         /**
-         * Calculates the first-order multivariable chained derivative of a multivariable function composed with a parametric curve function at a value.
+         * Calculates the first-order multivariable chained derivative of a multivariable function composed with a parametric curve at a value.
          * @param {ChalkboardFunction} func1 - The multivariable function
          * @param {ChalkboardFunction} func2 - The parametric curve function
          * @param {number} val - The value
          * @returns {number}
          */
         export const dfrdt = (func1: ChalkboardFunction, func2: ChalkboardFunction, val: number): number => {
-            if (func1.type === "mult") {
-                if (func2.type === "curv") {
-                    if (func2.definition.length === 2) {
-                        const g = Chalkboard.calc.grad(func1, Chalkboard.real.val(func2, val) as ChalkboardVector) as ChalkboardVector as { x: number, y: number, z?: number, w?: number },
-                            d = Chalkboard.calc.dfdx(func2, val) as ChalkboardVector as { x: number, y: number, z?: number, w?: number };
-                        const dfdx = g.x,
-                            dfdy = g.y,
-                            dxdt = d.x,
-                            dydt = d.y;
-                        return dfdx * dxdt + dfdy * dydt;
-                    } else {
-                        const g = Chalkboard.calc.grad(func1, Chalkboard.real.val(func2, val) as ChalkboardVector) as ChalkboardVector as { x: number, y: number, z?: number, w?: number },
-                            d = Chalkboard.calc.dfdx(func2, val) as ChalkboardVector as { x: number, y: number, z?: number, w?: number };
-                        const dfdx = g.x,
-                            dfdy = g.y,
-                            dfdz = g.z,
-                            dxdt = d.x,
-                            dydt = d.y,
-                            dzdt = d.z;
-                        return dfdx * dxdt + dfdy * dydt + dfdz! * dzdt!;
-                    }
-                } else {
-                    throw new TypeError('Parameter "func2" must be of type "ChalkboardFunction" with a "type" property of "curv".');
-                }
-            } else {
-                throw new TypeError('Parameter "func1" must be of type "ChalkboardFunction" with a "type" property of "mult".');
+            if (func1.field !== "real" || func2.field !== "real") {
+                throw new TypeError("Chalkboard.calc.dfrdt: Properties 'field' of 'func1' and 'func2' must be 'real'.");
             }
+            if (func1.type !== "scalar3d") {
+                throw new TypeError("Chalkboard.calc.dfrdt: Property 'type' of 'func1' must be 'scalar3d'.");
+            }
+            const g = Chalkboard.calc.grad(func1, Chalkboard.real.val(func2, val) as ChalkboardVector) as ChalkboardVector as { x: number, y: number, z?: number, w?: number };
+            const d = Chalkboard.calc.dfdx(func2, val) as ChalkboardVector as { x: number, y: number, z?: number, w?: number };
+            if (func2.type === "curve2d") {
+                return g.x * d.x + g.y * d.y;
+            } else if (func2.type === "curve3d") {
+                return g.x * d.x + g.y * d.y + g.z! * d.z!;
+            }
+            throw new TypeError("Chalkboard.calc.dfrdt: Property 'type' of 'func2' must be 'curve2d' or 'curve3d'.");
         };
 
         /**
          * Calculates the divergence of a vector field at a vector.
-         * @param {ChalkboardVectorField} vectfield - The vector field
+         * @param {ChalkboardFunction} vectfield - The vector field
          * @param {ChalkboardVector} vect - The vector
          * @returns {number}
          */
-        export const div = (vectfield: ChalkboardVectorField, vect: ChalkboardVector): number => {
-            if (Chalkboard.vect.dimension(vectfield) === 2 || Chalkboard.vect.dimension(vectfield) === 3 || Chalkboard.vect.dimension(vectfield) === 4) {
-                return Chalkboard.matr.trace(Chalkboard.calc.grad(vectfield, vect) as ChalkboardMatrix);
-            } else {
-                throw new TypeError('Parameter "vectfield" must be of type "ChalkboardVectorField" with 2, 3, or 4 dimensions.');
+        export const div = (vectfield: ChalkboardFunction, vect: ChalkboardVector): number => {
+            if (vectfield.field !== "real") {
+                throw new TypeError("Chalkboard.calc.div: Property 'field' of 'vectfield' must be 'real'.");
             }
+            if (vectfield.type === "vector2d" || vectfield.type === "vector3d" || vectfield.type === "vector4d") {
+                return Chalkboard.matr.trace(Chalkboard.calc.grad(vectfield, vect) as ChalkboardMatrix);
+            }
+            throw new TypeError("Chalkboard.calc.div: Property 'type' of 'vectfield' must be 'vector2d', 'vector3d', or 'vector4d'.");
         };
 
         /**
-         * Calculates the extrema of an explicit function within an interval of its domain.
+         * Calculates the extrema of a function within an interval of its domain.
          * @param {ChalkboardFunction} func - The function
          * @param {number[]} domain - The interval
          * @returns {number[]}
          */
         export const extrema = (func: ChalkboardFunction, domain: [number, number]): number[] => {
+            if (func.field !== "real" || func.type !== "scalar2d") {
+                throw new TypeError("Chalkboard.calc.extrema: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'scalar2d'.");
+            }
             const result = [];
             for (let i = domain[0]; i <= domain[1]; i++) {
                 if (Math.round(Chalkboard.calc.dfdx(func, i) as number) === 0) {
@@ -305,7 +292,7 @@ namespace Chalkboard {
         };
 
         /**
-         * Calculates the curve length or surface area of a parametric curve function or a parametric surface function, respectively.
+         * Calculates the curve length or surface area of a parametric curve or a parametric surface, respectively.
          * @param {ChalkboardFunction} func - The function
          * @param {number} tinf - The lower t-bound (for both curve length and surface area)
          * @param {number} tsup - The upper t-bound (for both curve length and surface area)
@@ -314,26 +301,21 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const fds = (func: ChalkboardFunction, tinf: number, tsup: number, sinf?: number, ssup?: number): number => {
+            if (func.field !== "real") {
+                throw new TypeError("Chalkboard.calc.fds: Property 'field' of 'func' must be 'real'.");
+            }
             let result = 0;
             let drdt, drds;
-            if (func.type === "curv") {
+            if (func.type === "curve2d" || func.type === "curve3d") {
                 const dt = (tsup - tinf) / 10000;
-                if (func.definition.length === 2) {
-                    for (let t = tinf; t <= tsup; t += dt) {
-                        drdt = Chalkboard.calc.dfdx(func, t);
-                        result += Chalkboard.vect.mag(drdt as ChalkboardVector);
-                    }
-                    return result * dt;
-                } else {
-                    for (let t = tinf; t <= tsup; t += dt) {
-                        drdt = Chalkboard.calc.dfdx(func, t);
-                        result += Chalkboard.vect.mag(drdt as ChalkboardVector);
-                    }
-                    return result * dt;
+                for (let t = tinf; t <= tsup; t += dt) {
+                    drdt = Chalkboard.calc.dfdx(func, t);
+                    result += Chalkboard.vect.mag(drdt as ChalkboardVector);
                 }
-            } else if (func.type === "surf") {
-                const dt = (tsup - tinf) / 100,
-                    ds = (ssup! - sinf!) / 100;
+                return result * dt;
+            } else if (func.type === "surface3d") {
+                const dt = (tsup - tinf) / 100;
+                const ds = (ssup! - sinf!) / 100;
                 for (let s = sinf; s! <= ssup!; s! += ds) {
                     for (let t = tinf; t <= tsup; t += dt) {
                         drds = Chalkboard.matr.toVector(Chalkboard.calc.grad(func, Chalkboard.vect.init(s!, t)) as ChalkboardMatrix, 3, 0, 0);
@@ -342,14 +324,13 @@ namespace Chalkboard {
                     }
                 }
                 return result * ds * dt;
-            } else {
-                throw new TypeError('Parameter "func" must be of type "ChalkboardFunction" with a "type" property of "curv" or "surf".');
             }
+            throw new TypeError("Chalkboard.calc.fds: Property 'type' of 'func' must be 'curve2d', 'curve3d', or 'surface3d'.");
         };
 
         /**
-         * Calculates the flux (line/surface integration over a vector field) of a parametric curve function or a parametric surface function through a 2D or 3D vector field, respectively.
-         * @param {ChalkboardVectorField} vectfield - The vector field
+         * Calculates the flux (line/surface integration over a vector field) of a parametric curve or a parametric surface through a 2D or 3D vector field, respectively.
+         * @param {ChalkboardFunction} vectfield - The vector field
          * @param {ChalkboardFunction} func - The function
          * @param {number} tinf - The lower t-bound (for both 2D and 3D)
          * @param {number} tsup - The upper t-bound (for both 2D and 3D)
@@ -357,30 +338,29 @@ namespace Chalkboard {
          * @param {number} [ssup] - The upper s-bound (only for 3D)
          * @returns {number}
          */
-        export const fnds = (vectfield: ChalkboardVectorField, func: ChalkboardFunction, tinf: number, tsup: number, sinf?: number, ssup?: number): number => {
+        export const fnds = (vectfield: ChalkboardFunction, func: ChalkboardFunction, tinf: number, tsup: number, sinf?: number, ssup?: number): number => {
+            if (vectfield.field !== "real" || func.field !== "real") {
+                throw new TypeError("Chalkboard.calc.fnds: Properties 'field' of 'vectfield' and 'func' must be 'real'.");
+            }
             let result = 0;
             let drdt, drds;
-            if (func.type === "curv") {
+            if (vectfield.type === "vector2d" && func.type === "curve2d") {
                 const dt = (tsup - tinf) / 10000;
-                if (func.definition.length === 2) {
-                    for (let t = tinf; t <= tsup; t += dt) {
-                        drdt = Chalkboard.calc.dfdx(func, t) as ChalkboardVector as { x: number, y: number, z?: number, w?: number };
-                        result +=
-                            Chalkboard.vect.dot(Chalkboard.vect.fromField(vectfield, Chalkboard.real.val(func, t) as ChalkboardVector), Chalkboard.vect.init(-drdt.y, drdt.x)) *
-                            Chalkboard.vect.mag(drdt);
-                    }
-                    return result * dt;
-                } else {
-                    for (let t = tinf; t <= tsup; t += dt) {
-                        drdt = Chalkboard.calc.dfdx(func, t) as ChalkboardVector;
-                        result +=
-                            Chalkboard.vect.dot(Chalkboard.vect.fromField(vectfield, Chalkboard.real.val(func, t) as ChalkboardVector), Chalkboard.calc.normal(func, t)) * Chalkboard.vect.mag(drdt);
-                    }
-                    return result * dt;
+                for (let t = tinf; t <= tsup; t += dt) {
+                    drdt = Chalkboard.calc.dfdx(func, t) as ChalkboardVector as { x: number, y: number, z?: number, w?: number };
+                    result += Chalkboard.vect.dot(Chalkboard.vect.fromField(vectfield, Chalkboard.real.val(func, t) as ChalkboardVector), Chalkboard.vect.init(-drdt.y, drdt.x)) * Chalkboard.vect.mag(drdt);
                 }
-            } else if (func.type === "surf") {
-                const dt = (tsup - tinf) / 100,
-                    ds = (ssup! - sinf!) / 100;
+                return result * dt;
+            } else if (vectfield.type === "vector3d" && func.type === "curve3d") {
+                const dt = (tsup - tinf) / 10000;
+                for (let t = tinf; t <= tsup; t += dt) {
+                    drdt = Chalkboard.calc.dfdx(func, t) as ChalkboardVector;
+                    result += Chalkboard.vect.dot(Chalkboard.vect.fromField(vectfield, Chalkboard.real.val(func, t) as ChalkboardVector), Chalkboard.calc.normal(func, t)) * Chalkboard.vect.mag(drdt);
+                }
+                return result * dt;
+            } else if (vectfield.type === "vector3d" && func.type === "surface3d") {
+                const dt = (tsup - tinf) / 100;
+                const ds = (ssup! - sinf!) / 100;
                 for (let s = sinf; s! <= ssup!; s! += ds) {
                     for (let t = tinf; t <= tsup; t += dt) {
                         drds = Chalkboard.matr.toVector(Chalkboard.calc.grad(func, Chalkboard.vect.init(s!, t)) as ChalkboardMatrix, 3, 0, 0);
@@ -389,111 +369,108 @@ namespace Chalkboard {
                     }
                 }
                 return result * ds * dt;
-            } else {
-                throw new TypeError('Parameter "func" must be of type "ChalkboardFunction" with a "type" property of "curv" or "surf".');
             }
+            throw new TypeError("Chalkboard.calc.fnds: Property 'type' of 'vectfield' must be 'vector2d' or 'vector3d' and property 'type' of 'func' must be 'curve2d', 'curve3d', or 'surface3d'.");
         };
 
         /**
-         * Calculates the Fourier transform of an explicit function at a value.
+         * Calculates the Fourier transform of a function at a value.
          * @param {ChalkboardFunction} func - The function
          * @param {number} val - The value
          * @returns {number}
          */
         export const Fourier = (func: ChalkboardFunction, val: number): number => {
-            return (2 * (Chalkboard.calc.fxdx(Chalkboard.real.define("(" + func.definition + ") * Math.cos(" + val + " * x)"), 0, 10) as number)) / Chalkboard.PI();
+            if (func.field !== "real" || func.type !== "scalar2d") {
+                throw new TypeError("Chalkboard.calc.Fourier: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'scalar2d'.");
+            }
+            const f = func.rule as (x: number) => number;
+            const g = (x: number): number => f(x) * Math.cos(val * x);
+            return (2 * (Chalkboard.calc.fxdx(Chalkboard.real.define(g), 0, 10) as number)) / Chalkboard.PI();
         };
 
         /**
          * Calculates the circulation (line integration over a scalar/vector field) of a parametric curve through a multivariable function or a vector field.
-         * @param {ChalkboardFunction | ChalkboardVectorField} funcORvectfield - The multivariable function or vector field
+         * @param {ChalkboardFunction} funcORvectfield - The multivariable function or vector field
          * @param {ChalkboardFunction} func - The parametric curve function
          * @param {number} inf - The lower bound
          * @param {number} sup - The upper bound
          * @returns {number}
          */
-        export const frds = (funcORvectfield: ChalkboardFunction | ChalkboardVectorField, func: ChalkboardFunction, inf: number, sup: number): number => {
-            const funct = funcORvectfield as ChalkboardFunction;
-            const vectfield = funcORvectfield as ChalkboardVectorField;
-            if (func.type === "curv") {
+        export const frds = (funcORvectfield: ChalkboardFunction, func: ChalkboardFunction, inf: number, sup: number): number => {
+            if (funcORvectfield.field !== "real" || func.field !== "real") {
+                throw new TypeError("Chalkboard.calc.frds: Properties 'field' of 'funcORvectfield' and 'func' must be 'real'.");
+            }
+            const f = funcORvectfield.rule as (x: number, y: number) => number;
+            if (func.type === "curve2d" || func.type === "curve3d") {
                 let result = 0;
                 const dt = (sup - inf) / 10000;
-                if (funct.type === "mult") {
+                if (funcORvectfield.type === "scalar2d") {
                     for (let t = inf; t <= sup; t += dt) {
-                        result += (Chalkboard.real.val(funct, Chalkboard.real.val(func, t)) as number) * Chalkboard.vect.mag(Chalkboard.calc.dfdx(func, t) as ChalkboardVector);
+                        const val = Chalkboard.real.val(func, t) as ChalkboardVector as { x: number, y: number, z?: number, w?: number };
+                        result += f(val.x, val.y) * Chalkboard.vect.mag(Chalkboard.calc.dfdx(func, t) as ChalkboardVector);
                     }
                     return result * dt;
-                } else if (Chalkboard.vect.dimension(vectfield) === 2) {
+                } else if (funcORvectfield.type === "vector2d") {
                     for (let t = inf; t <= sup; t += dt) {
-                        result += Chalkboard.vect.dot(Chalkboard.vect.fromField(vectfield, Chalkboard.real.val(func, t) as ChalkboardVector), Chalkboard.calc.dfdx(func, t) as ChalkboardVector);
+                        const val = Chalkboard.real.val(func, t) as ChalkboardVector;
+                        result += Chalkboard.vect.dot(Chalkboard.vect.fromField(funcORvectfield, val), Chalkboard.calc.dfdx(func, t) as ChalkboardVector);
                     }
                     return result * dt;
-                } else if (Chalkboard.vect.dimension(vectfield) === 3) {
+                } else if (funcORvectfield.type === "vector3d") {
                     for (let t = inf; t <= sup; t += dt) {
-                        result += Chalkboard.vect.dot(Chalkboard.vect.fromField(vectfield, Chalkboard.real.val(func, t) as ChalkboardVector), Chalkboard.calc.dfdx(func, t) as ChalkboardVector);
+                        const val = Chalkboard.real.val(func, t) as ChalkboardVector;
+                        result += Chalkboard.vect.dot(Chalkboard.vect.fromField(funcORvectfield, val), Chalkboard.calc.dfdx(func, t) as ChalkboardVector);
                     }
                     return result * dt;
-                } else {
-                    throw new TypeError('Parameter "func" must be of type "ChalkboardFunction" with a "type" property of "mult" or it must be of type "ChalkboardVectorField".');
                 }
-            } else {
-                throw new TypeError('Parameter "func" must be of type "ChalkboardFunction" with a "type" property of "curv".');
+                throw new TypeError("Chalkboard.calc.frds: Property 'type' of 'funcORvectfield' must be 'scalar2d', 'vector2d', or 'vector3d'.");
             }
+            throw new TypeError("Chalkboard.calc.frds: Property 'type' of 'func' must be 'curve2d' or 'curve3d'.");
         };
 
         /**
-         * Calculates the antiderivative (or integral) of an explicit, inverse, polar, or parametric curve function.
+         * Calculates the antiderivative (or integral) of a 2D scalar or parametric function within an interval.
          * @param {ChalkboardFunction} func - The function
          * @param {number} inf - The lower bound
          * @param {number} sup - The upper bound
          * @returns {number | ChalkboardVector}
          */
         export const fxdx = (func: ChalkboardFunction, inf: number, sup: number): number | ChalkboardVector => {
-            if (func.type === "expl" || func.type === "inve" || func.type === "pola") {
-                let f;
-                if (func.type === "expl") {
-                    f = Chalkboard.real.parse("x => " + func.definition);
-                } else if (func.type === "inve") {
-                    f = Chalkboard.real.parse("y => " + func.definition);
-                } else if (func.type === "pola") {
-                    f = Chalkboard.real.parse("O => " + "((" + func.definition + ") * (" + func.definition + ")) / 2");
-                }
-                let fx = f!(inf) + f!(sup);
+            if (func.field !== "real") {
+                throw new TypeError("Chalkboard.calc.fxdx: Property 'field' of 'func' must be 'real'.");
+            }
+            if (func.type === "scalar2d") {
+                const f = func.rule as (x: number) => number;
+                let fx = f(inf) + f(sup);
                 const dx = (sup - inf) / 1000000;
                 for (let i = 1; i < 1000000; i++) {
-                    fx += i % 2 === 0 ? 2 * f!(inf + i * dx) : 4 * f!(inf + i * dx);
+                    fx += i % 2 === 0 ? 2 * f(inf + i * dx) : 4 * f(inf + i * dx);
                 }
                 return (fx * dx) / 3;
-            } else if (func.type === "curv") {
-                if (func.definition.length === 2) {
-                    const x = Chalkboard.real.parse("t => " + func.definition[0]),
-                        y = Chalkboard.real.parse("t => " + func.definition[1]);
-                    let xt = x(inf) + x(sup),
-                        yt = y(inf) + y(sup);
-                    const dt = (sup - inf) / 1000000;
-                    for (let i = 1; i < 1000000; i++) {
-                        xt += i % 2 === 0 ? 2 * x(inf + i * dt) : 4 * x(inf + i * dt);
-                        yt += i % 2 === 0 ? 2 * y(sup + i * dt) : 4 * y(sup + i * dt);
-                    }
-                    return Chalkboard.vect.init((xt * dt) / 3, (yt * dt) / 3);
-                } else {
-                    const x = Chalkboard.real.parse("t => " + func.definition[0]),
-                        y = Chalkboard.real.parse("t => " + func.definition[1]),
-                        z = Chalkboard.real.parse("t => " + func.definition[2]);
-                    let xt = x(inf) + x(sup),
-                        yt = y(inf) + y(sup),
-                        zt = z(inf) + z(sup);
-                    const dt = (sup - inf) / 1000000;
-                    for (let i = 1; i < 1000000; i++) {
-                        xt += i % 2 === 0 ? 2 * x(inf + i * dt) : 4 * x(inf + i * dt);
-                        yt += i % 2 === 0 ? 2 * y(inf + i * dt) : 4 * y(inf + i * dt);
-                        zt += i % 2 === 0 ? 2 * z(inf + i * dt) : 4 * z(inf + i * dt);
-                    }
-                    return Chalkboard.vect.init((xt * dt) / 3, (yt * dt) / 3, (zt * dt) / 3);
+            } else if (func.type === "curve2d") {
+                const f = func.rule as ((t: number) => number)[];
+                let fx = f[0](inf) + f[0](sup);
+                let fy = f[1](inf) + f[1](sup);
+                const dt = (sup - inf) / 1000000;
+                for (let i = 1; i < 1000000; i++) {
+                    fx += i % 2 === 0 ? 2 * f[0](inf + i * dt) : 4 * f[0](inf + i * dt);
+                    fy += i % 2 === 0 ? 2 * f[1](inf + i * dt) : 4 * f[1](inf + i * dt);
                 }
-            } else {
-                throw new TypeError('Parameter "func" must be of type "ChalkboardFunction" with a "type" property of "expl", "inve", "pola", or "curv".');
+                return Chalkboard.vect.init((fx * dt) / 3, (fy * dt) / 3);
+            } else if (func.type === "curve3d") {
+                const f = func.rule as ((t: number) => number)[];
+                let fx = f[0](inf) + f[0](sup);
+                let fy = f[1](inf) + f[1](sup);
+                let fz = f[2](inf) + f[2](sup);
+                const dt = (sup - inf) / 1000000;
+                for (let i = 1; i < 1000000; i++) {
+                    fx += i % 2 === 0 ? 2 * f[0](inf + i * dt) : 4 * f[0](inf + i * dt);
+                    fy += i % 2 === 0 ? 2 * f[1](inf + i * dt) : 4 * f[1](inf + i * dt);
+                    fz += i % 2 === 0 ? 2 * f[2](inf + i * dt) : 4 * f[2](inf + i * dt);
+                }
+                return Chalkboard.vect.init((fx * dt) / 3, (fy * dt) / 3, (fz * dt) / 3);
             }
+            throw new TypeError("Chalkboard.calc.fxdx: Property 'type' of 'func' must be 'scalar2d', 'curve2d', or 'curve3d'.");
         };
 
         /**
@@ -506,201 +483,181 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const fxydxdy = (func: ChalkboardFunction, xinf: number, xsup: number, yinf: number, ysup: number): number => {
-            if (func.type === "mult") {
-                const f = Chalkboard.real.parse("(x, y) => " + func.definition);
+            if (func.field !== "real") {
+                throw new TypeError("Chalkboard.calc.fxydxdy: Property 'field' of 'func' must be 'real'.");
+            }
+            if (func.type === "scalar3d") {
+                const f = func.rule as (x: number, y: number) => number;
                 let result = 0;
-                const dx = (xsup - xinf) / 10000,
-                    dy = (ysup - yinf) / 10000;
+                const dx = (xsup - xinf) / 10000;
+                const dy = (ysup - yinf) / 10000;
                 for (let x = xinf; x <= xsup; x += dx) {
                     for (let y = yinf; y <= ysup; y += dy) {
                         result += f(x, y);
                     }
                 }
                 return result * dx * dy;
-            } else {
-                throw new TypeError('Parameter "func" must be of type "ChalkboardFunction" with a "type" property of "mult".');
             }
+            throw new TypeError("Chalkboard.calc.fxydxdy: Property 'type' of 'func' must be 'scalar3d'.");
         };
 
         /**
-         * Calculates the complex integration of a complex function composed with a parametric curve function.
+         * Calculates the complex integration of a complex function composed with a parametric curve.
          * @param {ChalkboardFunction} func1 - The complex function
-         * @param {ChalkboardFunction} func2 - The parametric curve function
+         * @param {ChalkboardFunction} func2 - The parametric curve
          * @param {number} inf - The lower bound
          * @param {number} sup - The upper bound
          * @returns
          */
         export const fzdz = (func1: ChalkboardFunction, func2: ChalkboardFunction, inf: number, sup: number): ChalkboardComplex => {
-            if (func1.type === "comp") {
-                if (func2.type === "curv") {
-                    let result = Chalkboard.comp.init(0, 0);
-                    const dt = (sup - inf) / 10000;
-                    for (let t = inf; t <= sup; t += dt) {
-                        const fz = Chalkboard.comp.val(func1, Chalkboard.vect.toComplex(Chalkboard.real.val(func2, t) as ChalkboardVector));
-                        const rt = Chalkboard.calc.dfdx(func2, t) as ChalkboardVector as { x: number, y: number, z?: number, w?: number };
-                        result = Chalkboard.comp.add(result, Chalkboard.comp.init(fz.a * rt.x - fz.b * rt.y, fz.b * rt.x + fz.a * rt.y));
-                    }
-                    return Chalkboard.comp.scl(result, dt);
-                } else {
-                    throw new TypeError('Parameter "func2" must be of type "ChalkboardFunction" with a "type" property of "curv".');
-                }
-            } else {
-                throw new TypeError('Parameter "func1" must be of type "ChalkboardFunction" with a "type" property of "comp".');
+            if (func1.field !== "comp" || func2.field !== "real") {
+                throw new TypeError("Chalkboard.calc.fzdz: Property 'field' of 'func1' must be 'comp' and property 'field' of 'func2' must be 'real'.");
             }
+            if (func1.type === "scalar3d" && func2.type === "curve2d") {
+                let result = Chalkboard.comp.init(0, 0);
+                const dt = (sup - inf) / 10000;
+                for (let t = inf; t <= sup; t += dt) {
+                    const fz = Chalkboard.comp.val(func1, Chalkboard.vect.toComplex(Chalkboard.real.val(func2, t) as ChalkboardVector));
+                    const rt = Chalkboard.calc.dfdx(func2, t) as ChalkboardVector as { x: number, y: number, z?: number, w?: number };
+                    result = Chalkboard.comp.add(result, Chalkboard.comp.init(fz.a * rt.x - fz.b * rt.y, fz.b * rt.x + fz.a * rt.y));
+                }
+                return Chalkboard.comp.scl(result, dt);
+            }
+            throw new TypeError("Chalkboard.calc.fzdz: Property 'type' of 'func1' must be 'scalar3d' and property 'type' of 'func2' must be 'curve2d'.");
         };
 
         /**
-         * Calculates the first-order gradient of a multivariable function, a parametric surface function, or a vector field at a vector.
-         * @param {ChalkboardFunction | ChalkboardVectorField} funcORvectfield - The function or vector field
+         * Calculates the first-order gradient of a multivariable function, a parametric surface, or a vector field at a vector.
+         * @param {ChalkboardFunction} funcORvectfield - The function or vector field
          * @param {ChalkboardVector} vect - The vector
          * @returns {ChalkboardVector | ChalkboardMatrix}
          */
-        export const grad = (funcORvectfield: ChalkboardFunction | ChalkboardVectorField, vect: ChalkboardVector): ChalkboardVector | ChalkboardMatrix => {
-            vect = vect as { x: number, y: number, z?: number, w?: number };
-            const h = 0.000000001;
-            const func = funcORvectfield as ChalkboardFunction;
-            const vectfield = funcORvectfield as ChalkboardVectorField;
-            if (func.type === "surf" && typeof vect.x === "number" && typeof vect.y === "number" && typeof vect.z === "undefined" && typeof vect.w === "undefined") {
-                const x = Chalkboard.real.parse("(s, t) => " + func.definition[0]),
-                    y = Chalkboard.real.parse("(s, t) => " + func.definition[1]),
-                    z = Chalkboard.real.parse("(s, t) => " + func.definition[2]);
-                const dxds = (x(vect.x + h, vect.y) - x(vect.x, vect.y)) / h,
-                    dxdt = (x(vect.x, vect.y + h) - x(vect.x, vect.y)) / h,
-                    dyds = (y(vect.x + h, vect.y) - y(vect.x, vect.y)) / h,
-                    dydt = (y(vect.x, vect.y + h) - y(vect.x, vect.y)) / h,
-                    dzds = (z(vect.x + h, vect.y) - z(vect.x, vect.y)) / h,
-                    dzdt = (z(vect.x, vect.y + h) - z(vect.x, vect.y)) / h;
-                return Chalkboard.matr.init([dxds, dxdt], [dyds, dydt], [dzds, dzdt]);
-            } else if (func.type === "mult" && typeof vect.x === "number" && typeof vect.y === "number" && typeof vect.z === "undefined" && typeof vect.w === "undefined") {
-                const f = Chalkboard.real.parse("(x, y) => " + func.definition);
-                const dfdx = (f(vect.x + h, vect.y) - f(vect.x, vect.y)) / h,
-                    dfdy = (f(vect.x, vect.y + h) - f(vect.x, vect.y)) / h;
-                return Chalkboard.vect.init(dfdx, dfdy);
-            } else if (Chalkboard.vect.dimension(vectfield) === 2 && typeof vect.x === "number" && typeof vect.y === "number" && typeof vect.z === "undefined" && typeof vect.w === "undefined") {
-                const p = Chalkboard.real.parse("(x, y) => " + vectfield.p),
-                    q = Chalkboard.real.parse("(x, y) => " + vectfield.q);
-                const dpdx = (p(vect.x + h, vect.y) - p(vect.x, vect.y)) / h,
-                    dpdy = (p(vect.x, vect.y + h) - p(vect.x, vect.y)) / h,
-                    dqdx = (q(vect.x + h, vect.y) - q(vect.x, vect.y)) / h,
-                    dqdy = (q(vect.x, vect.y + h) - q(vect.x, vect.y)) / h;
-                return Chalkboard.matr.init([dpdx, dpdy], [dqdx, dqdy]);
-            } else if (Chalkboard.vect.dimension(vectfield) === 3 && typeof vect.x === "number" && typeof vect.y === "number" && typeof vect.z === "number" && typeof vect.w === "undefined") {
-                const p = Chalkboard.real.parse("(x, y, z) => " + vectfield.p),
-                    q = Chalkboard.real.parse("(x, y, z) => " + vectfield.q),
-                    r = Chalkboard.real.parse("(x, y, z) => " + vectfield.r);
-                const dpdx = (p(vect.x + h, vect.y, vect.z) - p(vect.x, vect.y, vect.z)) / h,
-                    dpdy = (p(vect.x, vect.y + h, vect.z) - p(vect.x, vect.y, vect.z)) / h,
-                    dpdz = (p(vect.x, vect.y, vect.z + h) - p(vect.x, vect.y, vect.z)) / h,
-                    dqdx = (q(vect.x + h, vect.y, vect.z) - q(vect.x, vect.y, vect.z)) / h,
-                    dqdy = (q(vect.x, vect.y + h, vect.z) - q(vect.x, vect.y, vect.z)) / h,
-                    dqdz = (q(vect.x, vect.y, vect.z + h) - q(vect.x, vect.y, vect.z)) / h,
-                    drdx = (r(vect.x + h, vect.y, vect.z) - r(vect.x, vect.y, vect.z)) / h,
-                    drdy = (r(vect.x, vect.y + h, vect.z) - r(vect.x, vect.y, vect.z)) / h,
-                    drdz = (r(vect.x, vect.y, vect.z + h) - r(vect.x, vect.y, vect.z)) / h;
-                return Chalkboard.matr.init([dpdx, dpdy, dpdz], [dqdx, dqdy, dqdz], [drdx, drdy, drdz]);
-            } else if (Chalkboard.vect.dimension(vectfield) === 4 && typeof vect.x === "number" && typeof vect.y === "number" && typeof vect.z === "number" && typeof vect.w === "number") {
-                const p = Chalkboard.real.parse("(x, y, z, w) => " + vectfield.p),
-                    q = Chalkboard.real.parse("(x, y, z, w) => " + vectfield.q),
-                    r = Chalkboard.real.parse("(x, y, z, w) => " + vectfield.r),
-                    s = Chalkboard.real.parse("(x, y, z, w) => " + vectfield.s);
-                const dpdx = (p(vect.x + h, vect.y, vect.z, vect.w) - p(vect.x, vect.y, vect.z, vect.w)) / h,
-                    dpdy = (p(vect.x, vect.y + h, vect.z, vect.w) - p(vect.x, vect.y, vect.z, vect.w)) / h,
-                    dpdz = (p(vect.x, vect.y, vect.z + h, vect.w) - p(vect.x, vect.y, vect.z, vect.w)) / h,
-                    dpdw = (p(vect.x, vect.y, vect.z, vect.w + h) - p(vect.x, vect.y, vect.z, vect.w)) / h,
-                    dqdx = (q(vect.x + h, vect.y, vect.z, vect.w) - q(vect.x, vect.y, vect.z, vect.w)) / h,
-                    dqdy = (q(vect.x, vect.y + h, vect.z, vect.w) - q(vect.x, vect.y, vect.z, vect.w)) / h,
-                    dqdz = (q(vect.x, vect.y, vect.z + h, vect.w) - q(vect.x, vect.y, vect.z, vect.w)) / h,
-                    dqdw = (q(vect.x, vect.y, vect.z, vect.w + h) - q(vect.x, vect.y, vect.z, vect.w)) / h,
-                    drdx = (r(vect.x + h, vect.y, vect.z, vect.w) - r(vect.x, vect.y, vect.z, vect.w)) / h,
-                    drdy = (r(vect.x, vect.y + h, vect.z, vect.w) - r(vect.x, vect.y, vect.z, vect.w)) / h,
-                    drdz = (r(vect.x, vect.y, vect.z + h, vect.w) - r(vect.x, vect.y, vect.z, vect.w)) / h,
-                    drdw = (r(vect.x, vect.y, vect.z, vect.w + h) - r(vect.x, vect.y, vect.z, vect.w)) / h,
-                    dsdx = (s(vect.x + h, vect.y, vect.z, vect.w) - s(vect.x, vect.y, vect.z, vect.w)) / h,
-                    dsdy = (s(vect.x, vect.y + h, vect.z, vect.w) - s(vect.x, vect.y, vect.z, vect.w)) / h,
-                    dsdz = (s(vect.x, vect.y, vect.z + h, vect.w) - s(vect.x, vect.y, vect.z, vect.w)) / h,
-                    dsdw = (s(vect.x, vect.y, vect.z, vect.w + h) - s(vect.x, vect.y, vect.z, vect.w)) / h;
-                return Chalkboard.matr.init([dpdx, dpdy, dpdz, dpdw], [dqdx, dqdy, dqdz, dqdw], [drdx, drdy, drdz, drdw], [dsdx, dsdy, dsdz, dsdw]);
-            } else {
-                throw new TypeError('Parameter "funcORvectfield" must be of type "ChalkboardFunction" with a "type" property of "surf" or "mult" or of type "ChalkboardVectorField".');
+        export const grad = (funcORvectfield: ChalkboardFunction, vect: ChalkboardVector): ChalkboardVector | ChalkboardMatrix => {
+            if (funcORvectfield.field !== "real") {
+                throw new TypeError("Chalkboard.calc.grad: Property 'field' of 'funcORvectfield' must be 'real'.");
             }
+            const f = funcORvectfield.rule as (x: number, y: number) => number;
+            const r = funcORvectfield.rule as ((s: number, t: number) => number)[];
+            const F = funcORvectfield.rule as ((...x: number[]) => number)[];
+            const v = vect as { x: number, y: number, z?: number, w?: number };
+            const h = 0.000000001;
+            if (funcORvectfield.type === "scalar3d") {
+                const dfdx = (f(v.x + h, v.y) - f(v.x, v.y)) / h;
+                const dfdy = (f(v.x, v.y + h) - f(v.x, v.y)) / h;
+                return Chalkboard.vect.init(dfdx, dfdy);
+            } else if (funcORvectfield.type === "surface3d") {
+                const dxds = (r[0](v.x + h, v.y) - r[0](v.x, v.y)) / h;
+                const dxdt = (r[0](v.x, v.y + h) - r[0](v.x, v.y)) / h;
+                const dyds = (r[1](v.x + h, v.y) - r[1](v.x, v.y)) / h;
+                const dydt = (r[1](v.x, v.y + h) - r[1](v.x, v.y)) / h;
+                const dzds = (r[2](v.x + h, v.y) - r[2](v.x, v.y)) / h;
+                const dzdt = (r[2](v.x, v.y + h) - r[2](v.x, v.y)) / h;
+                return Chalkboard.matr.init([dxds, dxdt], [dyds, dydt], [dzds, dzdt]);
+            } else if (funcORvectfield.type === "vector2d") {
+                const dpdx = (F[0](v.x + h, v.y) - F[0](v.x, v.y)) / h;
+                const dpdy = (F[0](v.x, v.y + h) - F[0](v.x, v.y)) / h;
+                const dqdx = (F[1](v.x + h, v.y) - F[1](v.x, v.y)) / h;
+                const dqdy = (F[1](v.x, v.y + h) - F[1](v.x, v.y)) / h;
+                return Chalkboard.matr.init([dpdx, dpdy], [dqdx, dqdy]);
+            } else if (funcORvectfield.type === "vector3d") {
+                const dpdx = (F[0](v.x + h, v.y, v.z!) - F[0](v.x, v.y, v.z!)) / h;
+                const dpdy = (F[0](v.x, v.y + h, v.z!) - F[0](v.x, v.y, v.z!)) / h;
+                const dpdz = (F[0](v.x, v.y, v.z! + h) - F[0](v.x, v.y, v.z!)) / h;
+                const dqdx = (F[1](v.x + h, v.y, v.z!) - F[1](v.x, v.y, v.z!)) / h;
+                const dqdy = (F[1](v.x, v.y + h, v.z!) - F[1](v.x, v.y, v.z!)) / h;
+                const dqdz = (F[1](v.x, v.y, v.z! + h) - F[1](v.x, v.y, v.z!)) / h;
+                const drdx = (F[2](v.x + h, v.y, v.z!) - F[2](v.x, v.y, v.z!)) / h;
+                const drdy = (F[2](v.x, v.y + h, v.z!) - F[2](v.x, v.y, v.z!)) / h;
+                const drdz = (F[2](v.x, v.y, v.z! + h) - F[2](v.x, v.y, v.z!)) / h;
+                return Chalkboard.matr.init([dpdx, dpdy, dpdz], [dqdx, dqdy, dqdz], [drdx, drdy, drdz]);
+            } else if (funcORvectfield.type === "vector4d") {
+                const dpdx = (F[0](v.x + h, v.y, v.z!, v.w!) - F[0](v.x, v.y, v.z!, v.w!)) / h;
+                const dpdy = (F[0](v.x, v.y + h, v.z!, v.w!) - F[0](v.x, v.y, v.z!, v.w!)) / h;
+                const dpdz = (F[0](v.x, v.y, v.z! + h, v.w!) - F[0](v.x, v.y, v.z!, v.w!)) / h;
+                const dpdw = (F[0](v.x, v.y, v.z!, v.w! + h) - F[0](v.x, v.y, v.z!, v.w!)) / h;
+                const dqdx = (F[1](v.x + h, v.y, v.z!, v.w!) - F[1](v.x, v.y, v.z!, v.w!)) / h;
+                const dqdy = (F[1](v.x, v.y + h, v.z!, v.w!) - F[1](v.x, v.y, v.z!, v.w!)) / h;
+                const dqdz = (F[1](v.x, v.y, v.z! + h, v.w!) - F[1](v.x, v.y, v.z!, v.w!)) / h;
+                const dqdw = (F[1](v.x, v.y, v.z!, v.w! + h) - F[1](v.x, v.y, v.z!, v.w!)) / h;
+                const drdx = (F[2](v.x + h, v.y, v.z!, v.w!) - F[2](v.x, v.y, v.z!, v.w!)) / h;
+                const drdy = (F[2](v.x, v.y + h, v.z!, v.w!) - F[2](v.x, v.y, v.z!, v.w!)) / h;
+                const drdz = (F[2](v.x, v.y, v.z! + h, v.w!) - F[2](v.x, v.y, v.z!, v.w!)) / h;
+                const drdw = (F[2](v.x, v.y, v.z!, v.w! + h) - F[2](v.x, v.y, v.z!, v.w!)) / h;
+                const dsdx = (F[3](v.x + h, v.y, v.z!, v.w!) - F[3](v.x, v.y, v.z!, v.w!)) / h;
+                const dsdy = (F[3](v.x, v.y + h, v.z!, v.w!) - F[3](v.x, v.y, v.z!, v.w!)) / h;
+                const dsdz = (F[3](v.x, v.y, v.z! + h, v.w!) - F[3](v.x, v.y, v.z!, v.w!)) / h;
+                const dsdw = (F[3](v.x, v.y, v.z!, v.w! + h) - F[3](v.x, v.y, v.z!, v.w!)) / h;
+                return Chalkboard.matr.init([dpdx, dpdy, dpdz, dpdw], [dqdx, dqdy, dqdz, dqdw], [drdx, drdy, drdz, drdw], [dsdx, dsdy, dsdz, dsdw]);
+            }
+            throw new TypeError("Chalkboard.calc.grad: Property 'type' of 'funcORvectfield' must be 'scalar3d', 'surface3d', 'vector2d', 'vector3d', or 'vector4d'.");
         };
 
         /**
          * Calculates the second-order gradient of a multivariable function, a parametric surface function, or a vector field at a vector.
-         * @param {ChalkboardFunction | ChalkboardVectorField} funcORvectfield - The function or vector field
+         * @param {ChalkboardFunction} funcORvectfield - The function or vector field
          * @param {ChalkboardVector} vect - The vector
          * @returns {ChalkboardMatrix}
          */
-        export const grad2 = (funcORvectfield: ChalkboardFunction | ChalkboardVectorField, vect: ChalkboardVector): ChalkboardMatrix => {
-            vect = vect as { x: number, y: number, z?: number, w?: number };
-            const h = 0.00001;
-            const func = funcORvectfield as ChalkboardFunction;
-            const vectfield = funcORvectfield as ChalkboardVectorField;
-            if (func.type === "surf" && typeof vect.x === "number" && typeof vect.y === "number" && typeof vect.z === "undefined" && typeof vect.w === "undefined") {
-                const x = Chalkboard.real.parse("(s, t) => " + func.definition[0]),
-                    y = Chalkboard.real.parse("(s, t) => " + func.definition[1]),
-                    z = Chalkboard.real.parse("(s, t) => " + func.definition[2]);
-                const d2xds2 = (x(vect.x + h, vect.y) - 2 * x(vect.x, vect.y) + x(vect.x - h, vect.y)) / (h * h),
-                    d2xdt2 = (x(vect.x, vect.y + h) - 2 * x(vect.x, vect.y) + x(vect.x, vect.y - h)) / (h * h),
-                    d2yds2 = (y(vect.x + h, vect.y) - 2 * y(vect.x, vect.y) + y(vect.x - h, vect.y)) / (h * h),
-                    d2ydt2 = (y(vect.x, vect.y + h) - 2 * y(vect.x, vect.y) + y(vect.x, vect.y - h)) / (h * h),
-                    d2zds2 = (z(vect.x + h, vect.y) - 2 * z(vect.x, vect.y) + z(vect.x - h, vect.y)) / (h * h),
-                    d2zdt2 = (z(vect.x, vect.y + h) - 2 * z(vect.x, vect.y) + z(vect.x, vect.y - h)) / (h * h);
-                return Chalkboard.matr.init([d2xds2, d2xdt2], [d2yds2, d2ydt2], [d2zds2, d2zdt2]);
-            } else if (func.type === "mult" && typeof vect.x === "number" && typeof vect.y === "number" && typeof vect.z === "undefined" && typeof vect.w === "undefined") {
-                const f = Chalkboard.real.parse("(x, y) => " + func.definition);
-                const d2fdx2 = (f(vect.x + h, vect.y) - 2 * f(vect.x, vect.y) + f(vect.x - h, vect.y)) / (h * h),
-                    d2fdy2 = (f(vect.x, vect.y + h) - 2 * f(vect.x, vect.y) + f(vect.x, vect.y - h)) / (h * h),
-                    d2fdxdy = (f(vect.x + h, vect.y + h) - f(vect.x + h, vect.y) - f(vect.x, vect.y + h) + f(vect.x, vect.y)) / (h * h),
-                    d2fdydx = (f(vect.x + h, vect.y + h) - f(vect.x, vect.y + h) - f(vect.x + h, vect.y) + f(vect.x, vect.y)) / (h * h);
-                return Chalkboard.matr.init([d2fdx2, d2fdxdy], [d2fdydx, d2fdy2]);
-            } else if (Chalkboard.vect.dimension(vectfield) === 2 && typeof vect.x === "number" && typeof vect.y === "number" && typeof vect.z === "undefined" && typeof vect.w === "undefined") {
-                const p = Chalkboard.real.parse("(x, y) => " + vectfield.p),
-                    q = Chalkboard.real.parse("(x, y) => " + vectfield.q);
-                const d2pdx2 = (p(vect.x + h, vect.y) - 2 * p(vect.x, vect.y) + p(vect.x - h, vect.y)) / (h * h),
-                    d2pdy2 = (p(vect.x, vect.y + h) - 2 * p(vect.x, vect.y) + p(vect.x, vect.y - h)) / (h * h),
-                    d2qdx2 = (q(vect.x + h, vect.y) - 2 * q(vect.x, vect.y) + q(vect.x - h, vect.y)) / (h * h),
-                    d2qdy2 = (q(vect.x, vect.y + h) - 2 * q(vect.x, vect.y) + q(vect.x, vect.y - h)) / (h * h);
-                return Chalkboard.matr.init([d2pdx2, d2pdy2], [d2qdx2, d2qdy2]);
-            } else if (Chalkboard.vect.dimension(vectfield) === 3 && typeof vect.x === "number" && typeof vect.y === "number" && typeof vect.z === "number" && typeof vect.w === "undefined") {
-                const p = Chalkboard.real.parse("(x, y, z) => " + vectfield.p),
-                    q = Chalkboard.real.parse("(x, y, z) => " + vectfield.q),
-                    r = Chalkboard.real.parse("(x, y, z) => " + vectfield.r);
-                const d2pdx2 = (p(vect.x + h, vect.y, vect.z) - 2 * p(vect.x, vect.y, vect.z) + p(vect.x - h, vect.y, vect.z)) / (h * h),
-                    d2pdy2 = (p(vect.x, vect.y + h, vect.z) - 2 * p(vect.x, vect.y, vect.z) + p(vect.x, vect.y - h, vect.z)) / (h * h),
-                    d2pdz2 = (p(vect.x, vect.y, vect.z + h) - 2 * p(vect.x, vect.y, vect.z) + p(vect.x, vect.y, vect.z - h)) / (h * h),
-                    d2qdx2 = (q(vect.x + h, vect.y, vect.z) - 2 * q(vect.x, vect.y, vect.z) + q(vect.x - h, vect.y, vect.z)) / (h * h),
-                    d2qdy2 = (q(vect.x, vect.y + h, vect.z) - 2 * q(vect.x, vect.y, vect.z) + q(vect.x, vect.y - h, vect.z)) / (h * h),
-                    d2qdz2 = (q(vect.x, vect.y, vect.z + h) - 2 * q(vect.x, vect.y, vect.z) + q(vect.x, vect.y, vect.z - h)) / (h * h),
-                    d2rdx2 = (r(vect.x + h, vect.y, vect.z) - 2 * r(vect.x, vect.y, vect.z) + r(vect.x - h, vect.y, vect.z)) / (h * h),
-                    d2rdy2 = (r(vect.x, vect.y + h, vect.z) - 2 * r(vect.x, vect.y, vect.z) + r(vect.x, vect.y - h, vect.z)) / (h * h),
-                    d2rdz2 = (r(vect.x, vect.y, vect.z + h) - 2 * r(vect.x, vect.y, vect.z) + r(vect.x, vect.y, vect.z - h)) / (h * h);
-                return Chalkboard.matr.init([d2pdx2, d2pdy2, d2pdz2], [d2qdx2, d2qdy2, d2qdz2], [d2rdx2, d2rdy2, d2rdz2]);
-            } else if (Chalkboard.vect.dimension(vectfield) === 4 && typeof vect.x === "number" && typeof vect.y === "number" && typeof vect.z === "number" && typeof vect.w === "number") {
-                const p = Chalkboard.real.parse("(x, y, z, w) => " + vectfield.p),
-                    q = Chalkboard.real.parse("(x, y, z, w) => " + vectfield.q),
-                    r = Chalkboard.real.parse("(x, y, z, w) => " + vectfield.r),
-                    s = Chalkboard.real.parse("(x, y, z, w) => " + vectfield.s);
-                const d2pdx2 = (p(vect.x + h, vect.y, vect.z, vect.w) - 2 * p(vect.x, vect.y, vect.z, vect.w) + p(vect.x - h, vect.y, vect.z, vect.w)) / (h * h),
-                    d2pdy2 = (p(vect.x, vect.y + h, vect.z, vect.w) - 2 * p(vect.x, vect.y, vect.z, vect.w) + p(vect.x, vect.y - h, vect.z, vect.w)) / (h * h),
-                    d2pdz2 = (p(vect.x, vect.y, vect.z + h, vect.w) - 2 * p(vect.x, vect.y, vect.z, vect.w) + p(vect.x, vect.y, vect.z - h, vect.w)) / (h * h),
-                    d2pdw2 = (p(vect.x, vect.y, vect.z, vect.w + h) - 2 * p(vect.x, vect.y, vect.z, vect.w) + p(vect.x, vect.y, vect.z, vect.w - h)) / (h * h),
-                    d2qdx2 = (q(vect.x + h, vect.y, vect.z, vect.w) - 2 * q(vect.x, vect.y, vect.z, vect.w) + q(vect.x - h, vect.y, vect.z, vect.w)) / (h * h),
-                    d2qdy2 = (q(vect.x, vect.y + h, vect.z, vect.w) - 2 * q(vect.x, vect.y, vect.z, vect.w) + q(vect.x, vect.y - h, vect.z, vect.w)) / (h * h),
-                    d2qdz2 = (q(vect.x, vect.y, vect.z + h, vect.w) - 2 * q(vect.x, vect.y, vect.z, vect.w) + q(vect.x, vect.y, vect.z - h, vect.w)) / (h * h),
-                    d2qdw2 = (q(vect.x, vect.y, vect.z, vect.w + h) - 2 * q(vect.x, vect.y, vect.z, vect.w) + q(vect.x, vect.y, vect.z, vect.w - h)) / (h * h),
-                    d2rdx2 = (r(vect.x + h, vect.y, vect.z, vect.w) - 2 * r(vect.x, vect.y, vect.z, vect.w) + r(vect.x - h, vect.y, vect.z, vect.w)) / (h * h),
-                    d2rdy2 = (r(vect.x, vect.y + h, vect.z, vect.w) - 2 * r(vect.x, vect.y, vect.z, vect.w) + r(vect.x, vect.y - h, vect.z, vect.w)) / (h * h),
-                    d2rdz2 = (r(vect.x, vect.y, vect.z + h, vect.w) - 2 * r(vect.x, vect.y, vect.z, vect.w) + r(vect.x, vect.y, vect.z - h, vect.w)) / (h * h),
-                    d2rdw2 = (r(vect.x, vect.y, vect.z, vect.w + h) - 2 * r(vect.x, vect.y, vect.z, vect.w) + r(vect.x, vect.y, vect.z, vect.w - h)) / (h * h),
-                    d2sdx2 = (s(vect.x + h, vect.y, vect.z, vect.w) - 2 * s(vect.x, vect.y, vect.z, vect.w) + s(vect.x - h, vect.y, vect.z, vect.w)) / (h * h),
-                    d2sdy2 = (s(vect.x, vect.y + h, vect.z, vect.w) - 2 * s(vect.x, vect.y, vect.z, vect.w) + s(vect.x, vect.y - h, vect.z, vect.w)) / (h * h),
-                    d2sdz2 = (s(vect.x, vect.y, vect.z + h, vect.w) - 2 * s(vect.x, vect.y, vect.z, vect.w) + s(vect.x, vect.y, vect.z - h, vect.w)) / (h * h),
-                    d2sdw2 = (s(vect.x, vect.y, vect.z, vect.w + h) - 2 * s(vect.x, vect.y, vect.z, vect.w) + s(vect.x, vect.y, vect.z, vect.w - h)) / (h * h);
-                return Chalkboard.matr.init([d2pdx2, d2pdy2, d2pdz2, d2pdw2], [d2qdx2, d2qdy2, d2qdz2, d2qdw2], [d2rdx2, d2rdy2, d2rdz2, d2rdw2], [d2sdx2, d2sdy2, d2sdz2, d2sdw2]);
-            } else {
-                throw new TypeError('Parameter "funcORvectfield" must be of type "ChalkboardFunction" with a "type" property of "surf" or "mult" or it must be of type "ChalkboardVectorField".');
+        export const grad2 = (funcORvectfield: ChalkboardFunction, vect: ChalkboardVector): ChalkboardMatrix => {
+            if (funcORvectfield.field !== "real") {
+                throw new TypeError("Chalkboard.calc.grad2: Property 'field' of 'funcORvectfield' must be 'real'.");
             }
+            const f = funcORvectfield.rule as (x: number, y: number) => number;
+            const r = funcORvectfield.rule as ((s: number, t: number) => number)[];
+            const F = funcORvectfield.rule as ((...x: number[]) => number)[];
+            const v = vect as { x: number, y: number, z?: number, w?: number };
+            const h = 0.00001;
+            if (funcORvectfield.type === "scalar3d") {
+                const d2fdx2 = (f(v.x + h, v.y) - 2 * f(v.x, v.y) + f(v.x - h, v.y)) / (h * h);
+                const d2fdy2 = (f(v.x, v.y + h) - 2 * f(v.x, v.y) + f(v.x, v.y - h)) / (h * h);
+                const d2fdxdy = (f(v.x + h, v.y + h) - f(v.x + h, v.y) - f(v.x, v.y + h) + f(v.x, v.y)) / (h * h);
+                const d2fdydx = (f(v.x + h, v.y + h) - f(v.x, v.y + h) - f(v.x + h, v.y) + f(v.x, v.y)) / (h * h);
+                return Chalkboard.matr.init([d2fdx2, d2fdxdy], [d2fdydx, d2fdy2]);
+            } else if (funcORvectfield.type === "surface3d") {
+                const d2xds2 = (r[0](v.x + h, v.y) - 2 * r[0](v.x, v.y) + r[0](v.x - h, v.y)) / (h * h);
+                const d2xdt2 = (r[0](v.x, v.y + h) - 2 * r[0](v.x, v.y) + r[0](v.x, v.y - h)) / (h * h);
+                const d2yds2 = (r[1](v.x + h, v.y) - 2 * r[1](v.x, v.y) + r[1](v.x - h, v.y)) / (h * h);
+                const d2ydt2 = (r[1](v.x, v.y + h) - 2 * r[1](v.x, v.y) + r[1](v.x, v.y - h)) / (h * h);
+                const d2zds2 = (r[2](v.x + h, v.y) - 2 * r[2](v.x, v.y) + r[2](v.x - h, v.y)) / (h * h);
+                const d2zdt2 = (r[2](v.x, v.y + h) - 2 * r[2](v.x, v.y) + r[2](v.x, v.y - h)) / (h * h);
+                return Chalkboard.matr.init([d2xds2, d2xdt2], [d2yds2, d2ydt2], [d2zds2, d2zdt2]);
+            } else if (funcORvectfield.type === "vector2d") {
+                const d2pdx2 = (F[0](v.x + h, v.y) - 2 * F[0](v.x, v.y) + F[0](v.x - h, v.y)) / (h * h);
+                const d2pdy2 = (F[0](v.x, v.y + h) - 2 * F[0](v.x, v.y) + F[0](v.x, v.y - h)) / (h * h);
+                const d2qdx2 = (F[1](v.x + h, v.y) - 2 * F[1](v.x, v.y) + F[1](v.x - h, v.y)) / (h * h);
+                const d2qdy2 = (F[1](v.x, v.y + h) - 2 * F[1](v.x, v.y) + F[1](v.x, v.y - h)) / (h * h);
+                return Chalkboard.matr.init([d2pdx2, d2pdy2], [d2qdx2, d2qdy2]);
+            } else if (funcORvectfield.type === "vector3d") {
+                const d2pdx2 = (F[0](v.x + h, v.y, v.z!) - 2 * F[0](v.x, v.y, v.z!) + F[0](v.x - h, v.y, v.z!)) / (h * h);
+                const d2pdy2 = (F[0](v.x, v.y + h, v.z!) - 2 * F[0](v.x, v.y, v.z!) + F[0](v.x, v.y - h, v.z!)) / (h * h);
+                const d2pdz2 = (F[0](v.x, v.y, v.z! + h) - 2 * F[0](v.x, v.y, v.z!) + F[0](v.x, v.y, v.z! - h)) / (h * h);
+                const d2qdx2 = (F[1](v.x + h, v.y, v.z!) - 2 * F[1](v.x, v.y, v.z!) + F[1](v.x - h, v.y, v.z!)) / (h * h);
+                const d2qdy2 = (F[1](v.x, v.y + h, v.z!) - 2 * F[1](v.x, v.y, v.z!) + F[1](v.x, v.y - h, v.z!)) / (h * h);
+                const d2qdz2 = (F[1](v.x, v.y, v.z! + h) - 2 * F[1](v.x, v.y, v.z!) + F[1](v.x, v.y, v.z! - h)) / (h * h);
+                const d2rdx2 = (F[2](v.x + h, v.y, v.z!) - 2 * F[2](v.x, v.y, v.z!) + F[2](v.x - h, v.y, v.z!)) / (h * h);
+                const d2rdy2 = (F[2](v.x, v.y + h, v.z!) - 2 * F[2](v.x, v.y, v.z!) + F[2](v.x, v.y - h, v.z!)) / (h * h);
+                const d2rdz2 = (F[2](v.x, v.y, v.z! + h) - 2 * F[2](v.x, v.y, v.z!) + F[2](v.x, v.y, v.z! - h)) / (h * h);
+                return Chalkboard.matr.init([d2pdx2, d2pdy2, d2pdz2], [d2qdx2, d2qdy2, d2qdz2], [d2rdx2, d2rdy2, d2rdz2]);
+            } else if (funcORvectfield.type === "vector4d") {
+                const d2pdx2 = (F[0](v.x + h, v.y, v.z!, v.w!) - 2 * F[0](v.x, v.y, v.z!, v.w!) + F[0](v.x - h, v.y, v.z!, v.w!)) / (h * h);
+                const d2pdy2 = (F[0](v.x, v.y + h, v.z!, v.w!) - 2 * F[0](v.x, v.y, v.z!, v.w!) + F[0](v.x, v.y - h, v.z!, v.w!)) / (h * h);
+                const d2pdz2 = (F[0](v.x, v.y, v.z! + h, v.w!) - 2 * F[0](v.x, v.y, v.z!, v.w!) + F[0](v.x, v.y, v.z! - h, v.w!)) / (h * h);
+                const d2pdw2 = (F[0](v.x, v.y, v.z!, v.w! + h) - 2 * F[0](v.x, v.y, v.z!, v.w!) + F[0](v.x, v.y, v.z!, v.w! - h)) / (h * h);
+                const d2qdx2 = (F[1](v.x + h, v.y, v.z!, v.w!) - 2 * F[1](v.x, v.y, v.z!, v.w!) + F[1](v.x - h, v.y, v.z!, v.w!)) / (h * h);
+                const d2qdy2 = (F[1](v.x, v.y + h, v.z!, v.w!) - 2 * F[1](v.x, v.y, v.z!, v.w!) + F[1](v.x, v.y - h, v.z!, v.w!)) / (h * h);
+                const d2qdz2 = (F[1](v.x, v.y, v.z! + h, v.w!) - 2 * F[1](v.x, v.y, v.z!, v.w!) + F[1](v.x, v.y, v.z! - h, v.w!)) / (h * h);
+                const d2qdw2 = (F[1](v.x, v.y, v.z!, v.w! + h) - 2 * F[1](v.x, v.y, v.z!, v.w!) + F[1](v.x, v.y, v.z!, v.w! - h)) / (h * h);
+                const d2rdx2 = (F[2](v.x + h, v.y, v.z!, v.w!) - 2 * F[2](v.x, v.y, v.z!, v.w!) + F[2](v.x - h, v.y, v.z!, v.w!)) / (h * h);
+                const d2rdy2 = (F[2](v.x, v.y + h, v.z!, v.w!) - 2 * F[2](v.x, v.y, v.z!, v.w!) + F[2](v.x, v.y - h, v.z!, v.w!)) / (h * h);
+                const d2rdz2 = (F[2](v.x, v.y, v.z! + h, v.w!) - 2 * F[2](v.x, v.y, v.z!, v.w!) + F[2](v.x, v.y, v.z! - h, v.w!)) / (h * h);
+                const d2rdw2 = (F[2](v.x, v.y, v.z!, v.w! + h) - 2 * F[2](v.x, v.y, v.z!, v.w!) + F[2](v.x, v.y, v.z!, v.w! - h)) / (h * h);
+                const d2sdx2 = (F[3](v.x + h, v.y, v.z!, v.w!) - 2 * F[3](v.x, v.y, v.z!, v.w!) + F[3](v.x - h, v.y, v.z!, v.w!)) / (h * h);
+                const d2sdy2 = (F[3](v.x, v.y + h, v.z!, v.w!) - 2 * F[3](v.x, v.y, v.z!, v.w!) + F[3](v.x, v.y - h, v.z!, v.w!)) / (h * h);
+                const d2sdz2 = (F[3](v.x, v.y, v.z! + h, v.w!) - 2 * F[3](v.x, v.y, v.z!, v.w!) + F[3](v.x, v.y, v.z! - h, v.w!)) / (h * h);
+                const d2sdw2 = (F[3](v.x, v.y, v.z!, v.w! + h) - 2 * F[3](v.x, v.y, v.z!, v.w!) + F[3](v.x, v.y, v.z!, v.w! - h)) / (h * h);
+                return Chalkboard.matr.init([d2pdx2, d2pdy2, d2pdz2, d2pdw2], [d2qdx2, d2qdy2, d2qdz2, d2qdw2], [d2rdx2, d2rdy2, d2rdz2, d2rdw2], [d2sdx2, d2sdy2, d2sdz2, d2sdw2]);
+            }
+            throw new TypeError("Chalkboard.calc.grad: Property 'type' of 'funcORvectfield' must be 'scalar3d', 'surface3d', 'vector2d', 'vector3d', or 'vector4d'.");
         };
 
         /**
@@ -710,112 +667,117 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const Laplace = (func: ChalkboardFunction, val: number): number => {
-            if (val > 0) {
-                return Chalkboard.calc.fxdx(Chalkboard.real.define("(" + func.definition + ") * Math.exp(-" + val + " * x)"), 0, 10) as number;
-            } else {
-                throw new RangeError('Parameter "val" must be of type "number" greater than 0.');
+            if (func.field !== "real" || func.type !== "scalar2d") {
+                throw new TypeError("Chalkboard.calc.Laplace: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'scalar2d'.");
             }
+            if (val > 0) {
+                const f = func.rule as (x: number) => number;
+                const g = (x: number): number => f(x) * Math.exp(-val * x);
+                return Chalkboard.calc.fxdx(Chalkboard.real.define(g), 0, 10) as number;
+            }
+            throw new RangeError("Chalkboard.calc.Laplace: 'val' must be greater than 0.");
         };
 
         /**
-         * Calculates the limit of an explicit function as it approaches a value.
+         * Calculates the limit of a function as it approaches a value.
          * @param {ChalkboardFunction} func - The function
          * @param {number} val - The value
          * @returns {number | undefined}
          */
         export const lim = (func: ChalkboardFunction, val: number): number | undefined => {
-            if (func.type === "expl") {
-                if (val === Infinity) {
-                    if (Chalkboard.real.val(func, 101) > Chalkboard.real.val(func, 100)) {
-                        return Infinity;
-                    } else if (Chalkboard.real.val(func, 101) < Chalkboard.real.val(func, 100)) {
-                        return -Infinity;
-                    }
-                } else if (val === -Infinity) {
-                    if (Chalkboard.real.val(func, -101) > Chalkboard.real.val(func, -100)) {
-                        return Infinity;
-                    } else if (Chalkboard.real.val(func, -101) < Chalkboard.real.val(func, -100)) {
-                        return -Infinity;
-                    }
+            if (func.field !== "real" || func.type !== "scalar2d") {
+                throw new TypeError("Chalkboard.calc.lim: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'scalar2d'.");
+            }
+            const f = func.rule as (x: number) => number;
+            if (val === Infinity) {
+                if (f(101) > f(100)) {
+                    return Infinity;
+                } else if (f(101) < f(100)) {
+                    return -Infinity;
                 } else {
-                    if ((Chalkboard.real.val(func, val - 0.000001) as number).toFixed(4) === (Chalkboard.real.val(func, val + 0.000001) as number).toFixed(4)) {
-                        if (Chalkboard.real.val(func, val) !== Infinity || Chalkboard.real.val(func, val) !== -Infinity) {
-                            return Chalkboard.real.val(func, val) as number;
-                        } else {
-                            return undefined;
-                        }
+                    return f(100);
+                }
+            } else if (val === -Infinity) {
+                if (f(-101) > f(-100)) {
+                    return Infinity;
+                } else if (f(-101) < f(-100)) {
+                    return -Infinity;
+                } else {
+                    return f(-100);
+                }
+            } else {
+                if (f(val - 0.000001).toFixed(4) === f(val + 0.000001).toFixed(4)) {
+                    if (f(val) !== Infinity && f(val) !== -Infinity) {
+                        return f(val);
                     } else {
                         return undefined;
                     }
+                } else {
+                    return undefined;
                 }
-            } else {
-                throw new TypeError('Parameter "func" must be of type "ChalkboardFunction" with a "type" property of "expl".');
             }
         };
 
         /**
-         * Calculates the mean value of an explicit function within an interval.
+         * Calculates the mean value of a function within an interval.
          * @param {ChalkboardFunction} func - The function
          * @param {number} inf - The lower bound
          * @param {number} sup - The upper bound
          * @returns {number}
          */
         export const mean = (func: ChalkboardFunction, inf: number, sup: number): number => {
+            if (func.field !== "real" || func.type !== "scalar2d") {
+                throw new TypeError("Chalkboard.calc.mean: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'scalar2d'.");
+            }
             return (Chalkboard.calc.fxdx(func, inf, sup) as number) / (sup - inf);
         };
 
         /**
-         * Calculates a root of an explicit function with Newton's method within an interval.
+         * Calculates a root of a function with Newton's method within an interval.
          * @param {ChalkboardFunction} func - The function
          * @param {number[]} [domain=[-1, 1]] - The interval
          * @returns {number}
          */
         export const Newton = (func: ChalkboardFunction, domain: [number, number] = [-1, 1]): number => {
+            if (func.field !== "real" || func.type !== "scalar2d") {
+                throw new TypeError("Chalkboard.calc.Newton: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'scalar2d'.");
+            }
+            const f = func.rule as (x: number) => number;
             let x = Chalkboard.numb.random(domain[0], domain[1]);
             for (let i = 0; i < 10; i++) {
-                x = x - (Chalkboard.real.val(func, x) as number) / (Chalkboard.calc.dfdx(func, x) as number);
+                x = x - f(x) / (Chalkboard.calc.dfdx(func, x) as number);
             }
             return x;
         };
 
         /**
-         * Calculates the unit normal vector of a parametric curve function at a value.
+         * Calculates the unit normal vector of a parametric curve at a value.
          * @param {ChalkboardFunction} func - The function
          * @param {number} val - The value
          * @returns {ChalkboardVector}
          */
         export const normal = (func: ChalkboardFunction, val: number): ChalkboardVector => {
-            if (func.type === "curv") {
-                if (func.definition.length === 2) {
-                    return Chalkboard.vect.normalize(Chalkboard.calc.d2fdx2(func, val) as ChalkboardVector);
-                } else {
-                    return Chalkboard.vect.normalize(Chalkboard.calc.d2fdx2(func, val) as ChalkboardVector);
-                }
-            } else {
-                throw new TypeError('Parameter "func" must be of type "ChalkboardFunction" with a "type" property of "curv".');
+            if (func.field !== "real" || !func.type.startsWith("curve")) {
+                throw new TypeError("Chalkboard.calc.normal: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'curve2d' or 'curve3d'.");
             }
+            return Chalkboard.vect.normalize(Chalkboard.calc.d2fdx2(func, val) as ChalkboardVector);
         };
 
         /**
-         * Calculates the unit tangent vector of a parametric curve function at a value.
+         * Calculates the unit tangent vector of a parametric curve at a value.
          * @param {ChalkboardFunction} func - The function
          * @param {number} val - The value
          * @returns {ChalkboardVector}
          */
         export const tangent = (func: ChalkboardFunction, val: number): ChalkboardVector => {
-            if (func.type === "curv") {
-                if (func.definition.length === 2) {
-                    return Chalkboard.vect.normalize(Chalkboard.calc.dfdx(func, val) as ChalkboardVector);
-                } else {
-                    return Chalkboard.vect.normalize(Chalkboard.calc.dfdx(func, val) as ChalkboardVector);
-                }
-            } else {
-                throw new TypeError('Parameter "func" must be of type "ChalkboardFunction" with a "type" property of "curv".');
+            if (func.field !== "real" || !func.type.startsWith("curve")) {
+                throw new TypeError("Chalkboard.calc.tangent: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'curve2d' or 'curve3d'.");
             }
+            return Chalkboard.vect.normalize(Chalkboard.calc.dfdx(func, val) as ChalkboardVector);
         };
 
         /**
-         * Calculates the nth-degree Taylor series approximation of an explicit function at a value centered around another value.
+         * Calculates the nth-degree Taylor series approximation of a function at a value centered around another value.
          * @param {ChalkboardFunction} func - The function
          * @param {number} val - The value
          * @param {number} n - The degree
@@ -823,19 +785,19 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const Taylor = (func: ChalkboardFunction, val: number, n: 0 | 1 | 2, a: number): number => {
-            if (func.type === "expl") {
-                if (n === 0) {
-                    return Chalkboard.real.val(func, a) as number;
-                } else if (n === 1) {
-                    return (Chalkboard.real.val(func, a) as number) + (Chalkboard.calc.dfdx(func, a) as number) * (val - a);
-                } else if (n === 2) {
-                    return (Chalkboard.real.val(func, a) as number) + (Chalkboard.calc.dfdx(func, a) as number) * (val - a) + ((Chalkboard.calc.d2fdx2(func, a) as number) * (val - a) * (val - a)) / 2;
-                } else {
-                    throw new RangeError('Parameter "n" must be of type "number" greater than 0 and less than 3');
-                }
-            } else {
-                throw new TypeError('Parameter "func" must be of type "ChalkboardFunction" with a "type" property of "expl".');
+            if (func.field !== "real" || func.type !== "scalar2d") {
+                throw new TypeError("Chalkboard.calc.Taylor: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'scalar2d'.");
             }
+            const f = func.rule as (x: number) => number;
+            const x = val;
+            if (n === 0) {
+                return f(x);
+            } else if (n === 1) {
+                return f(x) + (Chalkboard.calc.dfdx(func, a) as number) * (x - a);
+            } else if (n === 2) {
+                return f(x) + (Chalkboard.calc.dfdx(func, a) as number) * (x - a) + ((Chalkboard.calc.d2fdx2(func, a) as number) * (x - a) * (x - a)) / 2;
+            }
+            throw new RangeError("Chalkboard.calc.Taylor: 'n' must be 0, 1, or 2.");
         };
     }
 }

--- a/src/Chalkboard-calc.ts
+++ b/src/Chalkboard-calc.ts
@@ -16,9 +16,7 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const autocorrelation = (func: ChalkboardFunction, val: number): number => {
-            if (func.field !== "real" || func.type !== "scalar2d") {
-                throw new TypeError("Chalkboard.calc.autocorrelation: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'scalar2d'.");
-            }
+            if (func.field !== "real" || func.type !== "scalar2d") throw new TypeError("Chalkboard.calc.autocorrelation: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'scalar2d'.");
             return Chalkboard.calc.correlation(func, func, val);
         };
 
@@ -29,9 +27,7 @@ namespace Chalkboard {
          * @returns {ChalkboardVector}
          */
         export const binormal = (func: ChalkboardFunction, val: number): ChalkboardVector => {
-            if (func.field !== "real") {
-                throw new TypeError("Chalkboard.calc.binormal: Property 'field' of 'func' must be 'real'.");
-            }
+            if (func.field !== "real") throw new TypeError("Chalkboard.calc.binormal: Property 'field' of 'func' must be 'real'.");
             if (func.type.startsWith("curve")) {
                 return Chalkboard.vect.cross(Chalkboard.calc.tangent(func, val), Chalkboard.calc.normal(func, val));
             }
@@ -46,9 +42,7 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const convolution = (func1: ChalkboardFunction, func2: ChalkboardFunction, val: number): number => {
-            if (func1.field !== "real" || func2.field !== "real" || func1.type !== "scalar2d" || func2.type !== "scalar2d") {
-                throw new TypeError("Chalkboard.calc.convolution: Properties 'field' of 'func1' and 'func2' must be 'real' and properties 'type' of 'func1' and 'func2' must be 'scalar2d'.");
-            }
+            if (func1.field !== "real" || func2.field !== "real" || func1.type !== "scalar2d" || func2.type !== "scalar2d") throw new TypeError("Chalkboard.calc.convolution: Properties 'field' of 'func1' and 'func2' must be 'real' and properties 'type' of 'func1' and 'func2' must be 'scalar2d'.");
             const f1 = func1.rule as (x: number) => number;
             const f2 = func2.rule as (x: number) => number;
             const g = (x: number): number => f1(x) * f2(val - x);
@@ -63,9 +57,7 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const correlation = (func1: ChalkboardFunction, func2: ChalkboardFunction, val: number): number => {
-            if (func1.field !== "real" || func2.field !== "real" || func1.type !== "scalar2d" || func2.type !== "scalar2d") {
-                throw new TypeError("Chalkboard.calc.correlation: Properties 'field' of 'func1' and 'func2' must be 'real' and properties 'type' of 'func1' and 'func2' must be 'scalar2d'.");
-            }
+            if (func1.field !== "real" || func2.field !== "real" || func1.type !== "scalar2d" || func2.type !== "scalar2d") throw new TypeError("Chalkboard.calc.correlation: Properties 'field' of 'func1' and 'func2' must be 'real' and properties 'type' of 'func1' and 'func2' must be 'scalar2d'.");
             const f1 = func1.rule as (x: number) => number; 
             const f2 = func2.rule as (x: number) => number;
             const g = (x: number): number => f1(x) * f2(val + x);
@@ -79,9 +71,7 @@ namespace Chalkboard {
          * @returns {ChalkboardVector}
          */
         export const curl = (vectfield: ChalkboardFunction, vect: ChalkboardVector): ChalkboardVector => {
-            if (vectfield.field !== "real") {
-                throw new TypeError("Chalkboard.calc.curl: Property 'field' of 'vectfield' must be 'real'.");
-            }
+            if (vectfield.field !== "real") throw new TypeError("Chalkboard.calc.curl: Property 'field' of 'vectfield' must be 'real'.");
             const f = vectfield.rule as ((...x: number[]) => number)[];
             const v = vect as { x: number, y: number, z?: number, w?: number };
             const h = 0.000000001;
@@ -108,9 +98,7 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const curvature = (func: ChalkboardFunction, val: number): number => {
-            if (func.field !== "real") {
-                throw new TypeError("Chalkboard.calc.curvature: Property 'field' of 'func' must be 'real'.");
-            }
+            if (func.field !== "real") throw new TypeError("Chalkboard.calc.curvature: Property 'field' of 'func' must be 'real'.");
             if (func.type === "curve2d") {
                 const d = Chalkboard.calc.dfdx(func, val) as ChalkboardVector as { x: number, y: number, z?: number, w?: number };
                 const d2 = Chalkboard.calc.d2fdx2(func, val) as ChalkboardVector as { x: number, y: number, z?: number, w?: number };
@@ -129,9 +117,7 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const dfdv = (func: ChalkboardFunction, vectpos: ChalkboardVector, vectdir: ChalkboardVector): number => {
-            if (func.field !== "real") {
-                throw new TypeError('Chalkboard.calc.dfdv: Property "field" of "func" must be "real".');
-            }
+            if (func.field !== "real") throw new TypeError('Chalkboard.calc.dfdv: Property "field" of "func" must be "real".');
             if (func.type === "scalar3d") {
                 const grad = Chalkboard.calc.grad(func, vectpos) as ChalkboardVector as { x: number, y: number, z?: number, w?: number };
                 const dir = Chalkboard.vect.normalize(vectdir);
@@ -147,9 +133,7 @@ namespace Chalkboard {
          * @returns {number | ChalkboardVector}
          */
         export const dfdx = (func: ChalkboardFunction, val: number): number | ChalkboardVector => {
-            if (func.field !== "real") {
-                throw new TypeError("Chalkboard.calc.dfdx: Property 'field' of 'func' must be 'real'.");
-            }
+            if (func.field !== "real") throw new TypeError("Chalkboard.calc.dfdx: Property 'field' of 'func' must be 'real'.");
             const h = 0.000000001;
             if (func.type === "scalar2d") {
                 const f = func.rule as (x: number) => number;
@@ -171,9 +155,7 @@ namespace Chalkboard {
          * @returns {number | ChalkboardVector}
          */
         export const d2fdx2 = (func: ChalkboardFunction, val: number): number | ChalkboardVector => {
-            if (func.field !== "real") {
-                throw new TypeError("Chalkboard.calc.d2fdx2: Property 'field' of 'func' must be 'real'.");
-            }
+            if (func.field !== "real") throw new TypeError("Chalkboard.calc.d2fdx2: Property 'field' of 'func' must be 'real'.");
             const h = 0.00001;
             if (func.type === "scalar2d") {
                 const f = func.rule as (x: number) => number;
@@ -195,11 +177,9 @@ namespace Chalkboard {
          * @returns {ChalkboardComplex[]}
          */
         export const dfdz = (func: ChalkboardFunction, comp: ChalkboardComplex): [ChalkboardComplex, ChalkboardComplex] => {
-            if (func.field !== "comp") {
-                throw new TypeError("Chalkboard.calc.dfdz: Property 'field' of 'func' must be 'comp'.");
-            }
+            if (func.field !== "comp") throw new TypeError("Chalkboard.calc.dfdz: Property 'field' of 'func' must be 'comp'.");
             const h = 0.000000001;
-            if (func.type === "scalar3d") {
+            if (func.type === "vector2d") {
                 const f = func.rule as [(a: number, b: number) => number, (a: number, b: number) => number];
                 const duda = (f[0](comp.a + h, comp.b) - f[0](comp.a, comp.b)) / h;
                 const dudb = (f[0](comp.a, comp.b + h) - f[0](comp.a, comp.b)) / h;
@@ -207,7 +187,7 @@ namespace Chalkboard {
                 const dvdb = (f[1](comp.a, comp.b + h) - f[1](comp.a, comp.b)) / h;
                 return [Chalkboard.comp.init(duda, dvda), Chalkboard.comp.init(dudb, dvdb)];
             }
-            throw new TypeError("Chalkboard.real.dfdz: Property 'type' of 'func' must be 'scalar3d'.");
+            throw new TypeError("Chalkboard.real.dfdz: Property 'type' of 'func' must be 'vector2d'.");
         };
 
         /**
@@ -217,11 +197,9 @@ namespace Chalkboard {
          * @returns {ChalkboardComplex[]}
          */
         export const d2fdz2 = (func: ChalkboardFunction, comp: ChalkboardComplex): [ChalkboardComplex, ChalkboardComplex] => {
-            if (func.field !== "comp") {
-                throw new TypeError("Chalkboard.calc.d2fdz2: Property 'field' of 'func' must be 'comp'.");
-            }
+            if (func.field !== "comp") throw new TypeError("Chalkboard.calc.d2fdz2: Property 'field' of 'func' must be 'comp'.");
             const h = 0.00001;
-            if (func.type === "scalar3d") {
+            if (func.type === "vector2d") {
                 const f = func.rule as [(a: number, b: number) => number, (a: number, b: number) => number];
                 const d2uda2 = (f[0](comp.a + h, comp.b) - 2 * f[0](comp.a, comp.b) + f[0](comp.a - h, comp.b)) / (h * h);
                 const d2udb2 = (f[0](comp.a, comp.b + h) - 2 * f[0](comp.a, comp.b) + f[0](comp.a, comp.b - h)) / (h * h);
@@ -229,7 +207,7 @@ namespace Chalkboard {
                 const d2vdb2 = (f[1](comp.a, comp.b + h) - 2 * f[1](comp.a, comp.b) + f[1](comp.a, comp.b - h)) / (h * h);
                 return [Chalkboard.comp.init(d2uda2, d2vda2), Chalkboard.comp.init(d2udb2, d2vdb2)];
             }
-            throw new TypeError("Chalkboard.real.d2fdz2: Property 'type' of 'func' must be 'scalar3d'.");
+            throw new TypeError("Chalkboard.real.d2fdz2: Property 'type' of 'func' must be 'vector2d'.");
         };
 
         /**
@@ -240,12 +218,8 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const dfrdt = (func1: ChalkboardFunction, func2: ChalkboardFunction, val: number): number => {
-            if (func1.field !== "real" || func2.field !== "real") {
-                throw new TypeError("Chalkboard.calc.dfrdt: Properties 'field' of 'func1' and 'func2' must be 'real'.");
-            }
-            if (func1.type !== "scalar3d") {
-                throw new TypeError("Chalkboard.calc.dfrdt: Property 'type' of 'func1' must be 'scalar3d'.");
-            }
+            if (func1.field !== "real" || func2.field !== "real") throw new TypeError("Chalkboard.calc.dfrdt: Properties 'field' of 'func1' and 'func2' must be 'real'.");
+            if (func1.type !== "scalar3d") throw new TypeError("Chalkboard.calc.dfrdt: Property 'type' of 'func1' must be 'scalar3d'.");
             const g = Chalkboard.calc.grad(func1, Chalkboard.real.val(func2, val) as ChalkboardVector) as ChalkboardVector as { x: number, y: number, z?: number, w?: number };
             const d = Chalkboard.calc.dfdx(func2, val) as ChalkboardVector as { x: number, y: number, z?: number, w?: number };
             if (func2.type === "curve2d") {
@@ -263,9 +237,7 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const div = (vectfield: ChalkboardFunction, vect: ChalkboardVector): number => {
-            if (vectfield.field !== "real") {
-                throw new TypeError("Chalkboard.calc.div: Property 'field' of 'vectfield' must be 'real'.");
-            }
+            if (vectfield.field !== "real") throw new TypeError("Chalkboard.calc.div: Property 'field' of 'vectfield' must be 'real'.");
             if (vectfield.type === "vector2d" || vectfield.type === "vector3d" || vectfield.type === "vector4d") {
                 return Chalkboard.matr.trace(Chalkboard.calc.grad(vectfield, vect) as ChalkboardMatrix);
             }
@@ -279,9 +251,7 @@ namespace Chalkboard {
          * @returns {number[]}
          */
         export const extrema = (func: ChalkboardFunction, domain: [number, number]): number[] => {
-            if (func.field !== "real" || func.type !== "scalar2d") {
-                throw new TypeError("Chalkboard.calc.extrema: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'scalar2d'.");
-            }
+            if (func.field !== "real" || func.type !== "scalar2d") throw new TypeError("Chalkboard.calc.extrema: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'scalar2d'.");
             const result = [];
             for (let i = domain[0]; i <= domain[1]; i++) {
                 if (Math.round(Chalkboard.calc.dfdx(func, i) as number) === 0) {
@@ -301,9 +271,7 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const fds = (func: ChalkboardFunction, tinf: number, tsup: number, sinf?: number, ssup?: number): number => {
-            if (func.field !== "real") {
-                throw new TypeError("Chalkboard.calc.fds: Property 'field' of 'func' must be 'real'.");
-            }
+            if (func.field !== "real") throw new TypeError("Chalkboard.calc.fds: Property 'field' of 'func' must be 'real'.");
             let result = 0;
             let drdt, drds;
             if (func.type === "curve2d" || func.type === "curve3d") {
@@ -339,9 +307,7 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const fnds = (vectfield: ChalkboardFunction, func: ChalkboardFunction, tinf: number, tsup: number, sinf?: number, ssup?: number): number => {
-            if (vectfield.field !== "real" || func.field !== "real") {
-                throw new TypeError("Chalkboard.calc.fnds: Properties 'field' of 'vectfield' and 'func' must be 'real'.");
-            }
+            if (vectfield.field !== "real" || func.field !== "real") throw new TypeError("Chalkboard.calc.fnds: Properties 'field' of 'vectfield' and 'func' must be 'real'.");
             let result = 0;
             let drdt, drds;
             if (vectfield.type === "vector2d" && func.type === "curve2d") {
@@ -380,9 +346,7 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const Fourier = (func: ChalkboardFunction, val: number): number => {
-            if (func.field !== "real" || func.type !== "scalar2d") {
-                throw new TypeError("Chalkboard.calc.Fourier: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'scalar2d'.");
-            }
+            if (func.field !== "real" || func.type !== "scalar2d") throw new TypeError("Chalkboard.calc.Fourier: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'scalar2d'.");
             const f = func.rule as (x: number) => number;
             const g = (x: number): number => f(x) * Math.cos(val * x);
             return (2 * (Chalkboard.calc.fxdx(Chalkboard.real.define(g), 0, 10) as number)) / Chalkboard.PI();
@@ -397,9 +361,7 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const frds = (funcORvectfield: ChalkboardFunction, func: ChalkboardFunction, inf: number, sup: number): number => {
-            if (funcORvectfield.field !== "real" || func.field !== "real") {
-                throw new TypeError("Chalkboard.calc.frds: Properties 'field' of 'funcORvectfield' and 'func' must be 'real'.");
-            }
+            if (funcORvectfield.field !== "real" || func.field !== "real") throw new TypeError("Chalkboard.calc.frds: Properties 'field' of 'funcORvectfield' and 'func' must be 'real'.");
             const f = funcORvectfield.rule as (x: number, y: number) => number;
             if (func.type === "curve2d" || func.type === "curve3d") {
                 let result = 0;
@@ -436,9 +398,7 @@ namespace Chalkboard {
          * @returns {number | ChalkboardVector}
          */
         export const fxdx = (func: ChalkboardFunction, inf: number, sup: number): number | ChalkboardVector => {
-            if (func.field !== "real") {
-                throw new TypeError("Chalkboard.calc.fxdx: Property 'field' of 'func' must be 'real'.");
-            }
+            if (func.field !== "real") throw new TypeError("Chalkboard.calc.fxdx: Property 'field' of 'func' must be 'real'.");
             if (func.type === "scalar2d") {
                 const f = func.rule as (x: number) => number;
                 let fx = f(inf) + f(sup);
@@ -483,9 +443,7 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const fxydxdy = (func: ChalkboardFunction, xinf: number, xsup: number, yinf: number, ysup: number): number => {
-            if (func.field !== "real") {
-                throw new TypeError("Chalkboard.calc.fxydxdy: Property 'field' of 'func' must be 'real'.");
-            }
+            if (func.field !== "real") throw new TypeError("Chalkboard.calc.fxydxdy: Property 'field' of 'func' must be 'real'.");
             if (func.type === "scalar3d") {
                 const f = func.rule as (x: number, y: number) => number;
                 let result = 0;
@@ -507,23 +465,21 @@ namespace Chalkboard {
          * @param {ChalkboardFunction} func2 - The parametric curve
          * @param {number} inf - The lower bound
          * @param {number} sup - The upper bound
-         * @returns
+         * @returns {ChalkboardComplex}
          */
         export const fzdz = (func1: ChalkboardFunction, func2: ChalkboardFunction, inf: number, sup: number): ChalkboardComplex => {
-            if (func1.field !== "comp" || func2.field !== "real") {
-                throw new TypeError("Chalkboard.calc.fzdz: Property 'field' of 'func1' must be 'comp' and property 'field' of 'func2' must be 'real'.");
-            }
-            if (func1.type === "scalar3d" && func2.type === "curve2d") {
+            if (func1.field !== "comp" || func2.field !== "real") throw new TypeError("Chalkboard.calc.fzdz: Property 'field' of 'func1' must be 'comp' and property 'field' of 'func2' must be 'real'.");
+            if (func1.type === "vector2d" && func2.type === "curve2d") {
                 let result = Chalkboard.comp.init(0, 0);
                 const dt = (sup - inf) / 10000;
                 for (let t = inf; t <= sup; t += dt) {
                     const fz = Chalkboard.comp.val(func1, Chalkboard.vect.toComplex(Chalkboard.real.val(func2, t) as ChalkboardVector));
                     const rt = Chalkboard.calc.dfdx(func2, t) as ChalkboardVector as { x: number, y: number, z?: number, w?: number };
-                    result = Chalkboard.comp.add(result, Chalkboard.comp.init(fz.a * rt.x - fz.b * rt.y, fz.b * rt.x + fz.a * rt.y));
+                    result = Chalkboard.comp.add(result, Chalkboard.comp.init(fz.a * rt.x - fz.b * rt.y, fz.b * rt.x + fz.a * rt.y)) as ChalkboardComplex;
                 }
-                return Chalkboard.comp.scl(result, dt);
+                return Chalkboard.comp.scl(result, dt) as ChalkboardComplex;
             }
-            throw new TypeError("Chalkboard.calc.fzdz: Property 'type' of 'func1' must be 'scalar3d' and property 'type' of 'func2' must be 'curve2d'.");
+            throw new TypeError("Chalkboard.calc.fzdz: Property 'type' of 'func1' must be 'vector2d' and property 'type' of 'func2' must be 'curve2d'.");
         };
 
         /**
@@ -533,9 +489,7 @@ namespace Chalkboard {
          * @returns {ChalkboardVector | ChalkboardMatrix}
          */
         export const grad = (funcORvectfield: ChalkboardFunction, vect: ChalkboardVector): ChalkboardVector | ChalkboardMatrix => {
-            if (funcORvectfield.field !== "real") {
-                throw new TypeError("Chalkboard.calc.grad: Property 'field' of 'funcORvectfield' must be 'real'.");
-            }
+            if (funcORvectfield.field !== "real") throw new TypeError("Chalkboard.calc.grad: Property 'field' of 'funcORvectfield' must be 'real'.");
             const f = funcORvectfield.rule as (x: number, y: number) => number;
             const r = funcORvectfield.rule as ((s: number, t: number) => number)[];
             const F = funcORvectfield.rule as ((...x: number[]) => number)[];
@@ -599,9 +553,7 @@ namespace Chalkboard {
          * @returns {ChalkboardMatrix}
          */
         export const grad2 = (funcORvectfield: ChalkboardFunction, vect: ChalkboardVector): ChalkboardMatrix => {
-            if (funcORvectfield.field !== "real") {
-                throw new TypeError("Chalkboard.calc.grad2: Property 'field' of 'funcORvectfield' must be 'real'.");
-            }
+            if (funcORvectfield.field !== "real") throw new TypeError("Chalkboard.calc.grad2: Property 'field' of 'funcORvectfield' must be 'real'.");
             const f = funcORvectfield.rule as (x: number, y: number) => number;
             const r = funcORvectfield.rule as ((s: number, t: number) => number)[];
             const F = funcORvectfield.rule as ((...x: number[]) => number)[];
@@ -667,9 +619,7 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const Laplace = (func: ChalkboardFunction, val: number): number => {
-            if (func.field !== "real" || func.type !== "scalar2d") {
-                throw new TypeError("Chalkboard.calc.Laplace: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'scalar2d'.");
-            }
+            if (func.field !== "real" || func.type !== "scalar2d") throw new TypeError("Chalkboard.calc.Laplace: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'scalar2d'.");
             if (val > 0) {
                 const f = func.rule as (x: number) => number;
                 const g = (x: number): number => f(x) * Math.exp(-val * x);
@@ -685,9 +635,7 @@ namespace Chalkboard {
          * @returns {number | undefined}
          */
         export const lim = (func: ChalkboardFunction, val: number): number | undefined => {
-            if (func.field !== "real" || func.type !== "scalar2d") {
-                throw new TypeError("Chalkboard.calc.lim: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'scalar2d'.");
-            }
+            if (func.field !== "real" || func.type !== "scalar2d") throw new TypeError("Chalkboard.calc.lim: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'scalar2d'.");
             const f = func.rule as (x: number) => number;
             if (val === Infinity) {
                 if (f(101) > f(100)) {
@@ -726,9 +674,7 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const mean = (func: ChalkboardFunction, inf: number, sup: number): number => {
-            if (func.field !== "real" || func.type !== "scalar2d") {
-                throw new TypeError("Chalkboard.calc.mean: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'scalar2d'.");
-            }
+            if (func.field !== "real" || func.type !== "scalar2d") throw new TypeError("Chalkboard.calc.mean: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'scalar2d'.");
             return (Chalkboard.calc.fxdx(func, inf, sup) as number) / (sup - inf);
         };
 
@@ -739,9 +685,7 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const Newton = (func: ChalkboardFunction, domain: [number, number] = [-1, 1]): number => {
-            if (func.field !== "real" || func.type !== "scalar2d") {
-                throw new TypeError("Chalkboard.calc.Newton: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'scalar2d'.");
-            }
+            if (func.field !== "real" || func.type !== "scalar2d") throw new TypeError("Chalkboard.calc.Newton: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'scalar2d'.");
             const f = func.rule as (x: number) => number;
             let x = Chalkboard.numb.random(domain[0], domain[1]);
             for (let i = 0; i < 10; i++) {
@@ -757,9 +701,7 @@ namespace Chalkboard {
          * @returns {ChalkboardVector}
          */
         export const normal = (func: ChalkboardFunction, val: number): ChalkboardVector => {
-            if (func.field !== "real" || !func.type.startsWith("curve")) {
-                throw new TypeError("Chalkboard.calc.normal: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'curve2d' or 'curve3d'.");
-            }
+            if (func.field !== "real" || !func.type.startsWith("curve")) throw new TypeError("Chalkboard.calc.normal: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'curve2d' or 'curve3d'.");
             return Chalkboard.vect.normalize(Chalkboard.calc.d2fdx2(func, val) as ChalkboardVector);
         };
 
@@ -770,9 +712,7 @@ namespace Chalkboard {
          * @returns {ChalkboardVector}
          */
         export const tangent = (func: ChalkboardFunction, val: number): ChalkboardVector => {
-            if (func.field !== "real" || !func.type.startsWith("curve")) {
-                throw new TypeError("Chalkboard.calc.tangent: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'curve2d' or 'curve3d'.");
-            }
+            if (func.field !== "real" || !func.type.startsWith("curve")) throw new TypeError("Chalkboard.calc.tangent: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'curve2d' or 'curve3d'.");
             return Chalkboard.vect.normalize(Chalkboard.calc.dfdx(func, val) as ChalkboardVector);
         };
 
@@ -785,9 +725,7 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const Taylor = (func: ChalkboardFunction, val: number, n: 0 | 1 | 2, a: number): number => {
-            if (func.field !== "real" || func.type !== "scalar2d") {
-                throw new TypeError("Chalkboard.calc.Taylor: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'scalar2d'.");
-            }
+            if (func.field !== "real" || func.type !== "scalar2d") throw new TypeError("Chalkboard.calc.Taylor: Property 'field' of 'func' must be 'real' and property 'type' of 'func' must be 'scalar2d'.");
             const f = func.rule as (x: number) => number;
             const x = val;
             if (n === 0) {

--- a/src/Chalkboard-comp.ts
+++ b/src/Chalkboard-comp.ts
@@ -24,9 +24,9 @@ namespace Chalkboard {
                 return Chalkboard.comp.init(Math.abs(z.a), Math.abs(z.b));
             } else if (comp.hasOwnProperty("rule")) {
                 if ((comp as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.absolute: Property 'field' of 'comp' must be 'comp'.");
-                const f = (comp as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const f = (comp as ChalkboardFunction).rule as ((a: number, b: number) => number)[];
                 const g = [(a: number, b: number) => Math.abs(f[0](a, b)), (a: number, b: number) => Math.abs(f[1](a, b))];
-                return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+                return Chalkboard.comp.define(...g);
             }
             throw new TypeError("Chalkboard.comp.absolute: Parameter 'comp' must be of type ChalkboardComplex, number, or ChalkboardFunction.");
         };
@@ -47,28 +47,12 @@ namespace Chalkboard {
                 const z1 = comp1 as ChalkboardComplex;
                 const z2 = comp2 as ChalkboardComplex;
                 return Chalkboard.comp.init(z1.a + z2.a, z1.b + z2.b);
-            } else if (comp1.hasOwnProperty("rule") || comp2.hasOwnProperty("rule")) {
-                if (comp1.hasOwnProperty("rule")) {
-                    if ((comp1 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.add: Property 'field' of 'comp1' must be 'comp'.");
-                    if (comp2.hasOwnProperty("rule")) {
-                        if ((comp2 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.add: Property 'field' of 'comp2' must be 'comp'.");
-                        const f1 = (comp1 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
-                        const f2 = (comp2 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
-                        const g = [(a: number, b: number) => f1[0](a, b) + f2[0](a, b), (a: number, b: number) => f1[1](a, b) + f2[1](a, b)];
-                        return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
-                    } else {
-                        const f = (comp1 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
-                        const z = comp2 as ChalkboardComplex;
-                        const g = [(a: number, b: number) => f[0](a, b) + z.a, (a: number, b: number) => f[1](a, b) + z.b];
-                        return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
-                    }
-                } else {
-                    if ((comp2 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.add: Property 'field' of 'comp2' must be 'comp'.");
-                    const z = comp1 as ChalkboardComplex;
-                    const f = (comp2 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
-                    const g = [(a: number, b: number) => z.a + f[0](a, b), (a: number, b: number) => z.b + f[1](a, b)];
-                    return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
-                }
+            } else if (comp1.hasOwnProperty("rule") && comp2.hasOwnProperty("rule")) {
+                if ((comp1 as ChalkboardFunction).field !== "comp" || (comp2 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.add: Properties 'field' of 'comp1' and 'comp2' must be 'comp'.");
+                const f1 = (comp1 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const f2 = (comp2 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const g = [(a: number, b: number) => f1[0](a, b) + f2[0](a, b), (a: number, b: number) => f1[1](a, b) + f2[1](a, b)];
+                return Chalkboard.comp.define(...g);
             }
             throw new TypeError("Chalkboard.comp.add: Parameters 'comp1' and 'comp2' must be of type ChalkboardComplex, number, or ChalkboardFunction.");
         };
@@ -113,9 +97,9 @@ namespace Chalkboard {
                 return Chalkboard.comp.init(z.a, -z.b);
             } else if (comp.hasOwnProperty("rule")) {
                 if ((comp as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.conjugate: Property 'field' of 'comp' must be 'comp'.");
-                const f = (comp as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const f = (comp as ChalkboardFunction).rule as ((a: number, b: number) => number)[];
                 const g = [(a: number, b: number) => f[0](a, b), (a: number, b: number) => -f[1](a, b)];
-                return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+                return Chalkboard.comp.define(...g);
             }
             throw new TypeError("Chalkboard.comp.conjugate: Parameter 'comp' must be of type ChalkboardComplex, number, or ChalkboardFunction.");
         };
@@ -146,7 +130,7 @@ namespace Chalkboard {
         };
 
         /**
-         * Defines a complex function by its real part and imaginary part.
+         * Defines a mathematical function in the field of complex numbers.
          * @param {Function | Function[]} rule - The rule of the function, which can be a single function that takes a complex number or an array of two functions that take real and imaginary parts respectively.
          * @returns {ChalkboardFunction}
          * @example
@@ -159,21 +143,24 @@ namespace Chalkboard {
          *     (a, b) => 2*a*b
          * ]);
          */
-        export const define = (
-            rule: ((z: ChalkboardComplex) => ChalkboardComplex) | ([(a: number, b: number) => number, (a: number, b: number) => number])
-        ): ChalkboardFunction => {
-            if (Array.isArray(rule)) {
-                if (rule.length !== 2 || rule[0].length !== 2 || rule[1].length !== 2) throw new TypeError("Chalkboard.comp.define: If 'rule' is an array, it must be an array of two functions of two variables.");
-                if (typeof rule[0](0, 0) !== "number" || typeof rule[1](0, 0) !== "number") throw new TypeError("Chalkboard.comp.define: If 'rule' is an array, the functions in it must return real numbers.");
-                return { rule, field: "comp", type: "vector2d" } as ChalkboardFunction;
+        export const define = (...rule: (((z: ChalkboardComplex) => ChalkboardComplex) | ((a: number, b: number) => number))[]): ChalkboardFunction => {
+            let f: ((z: ChalkboardComplex) => ChalkboardComplex) | ((a: number, b: number) => number)[] | ((a: number, b: number) => number);
+            if (rule.length === 1 && Array.isArray(rule[0])) {
+                f = rule[0] as ((a: number, b: number) => number)[];
+            } else if (rule.length > 1) {
+                f = rule as ((a: number, b: number) => number)[];
             } else {
-                if (rule.length !== 1) throw new TypeError("Chalkboard.comp.define: If 'rule' is a function, it must be a function of one variable.");
-                if (!rule(Chalkboard.comp.init(0, 0)).hasOwnProperty("a") || !rule(Chalkboard.comp.init(0, 0)).hasOwnProperty("b")) throw new TypeError("Chalkboard.comp.define: If 'rule' is a function, it must return a complex number.");
-                const f = rule as (z: ChalkboardComplex) => ChalkboardComplex;
-                return { rule: [
-                    (a: number, b: number) => f(Chalkboard.comp.init(a, b)).a,
-                    (a: number, b: number) => f(Chalkboard.comp.init(a, b)).b
-                ], field: "comp", type: "vector2d" } as ChalkboardFunction;
+                f = rule[0] as ((z: ChalkboardComplex) => ChalkboardComplex);
+            }
+            if (Array.isArray(f)) {
+                if (f.length !== 2 || f[0].length !== 2 || f[1].length !== 2) throw new TypeError("Chalkboard.comp.define: If 'rule' is an array, it must be an array of two functions of two variables.");
+                if (typeof f[0](0, 0) !== "number" || typeof f[1](0, 0) !== "number") throw new TypeError("Chalkboard.comp.define: If 'rule' is an array, the functions in it must return real numbers.");
+                return { rule: f, field: "comp", type: "vector2d" } as ChalkboardFunction;
+            } else {
+                if (f.length !== 1) throw new TypeError("Chalkboard.comp.define: If 'rule' is a function, it must be a function of one variable.");
+                const F = f as (z: ChalkboardComplex) => ChalkboardComplex;
+                if (!F(Chalkboard.comp.init(0, 0)).hasOwnProperty("a") || !F(Chalkboard.comp.init(0, 0)).hasOwnProperty("b")) throw new TypeError("Chalkboard.comp.define: If 'rule' is a function, it must return a complex number.");
+                return { rule: [(a: number, b: number) => F(Chalkboard.comp.init(a, b)).a, (a: number, b: number) => F(Chalkboard.comp.init(a, b)).b], field: "comp", type: "vector2d" } as ChalkboardFunction;
             }
         };
 
@@ -225,49 +212,20 @@ namespace Chalkboard {
                 const d = z2.a * z2.a + z2.b * z2.b;
                 return Chalkboard.comp.init((z1.a * z2.a + z1.b * z2.b) / d, (z1.b * z2.a - z1.a * z2.b) / d);
             } else if (comp1.hasOwnProperty("rule") || comp2.hasOwnProperty("rule")) {
-                if (comp1.hasOwnProperty("rule")) {
-                    if ((comp1 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.div: Property 'field' of 'comp1' must be 'comp'.");
-                    if (comp2.hasOwnProperty("rule")) {
-                        if ((comp2 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.div: Property 'field' of 'comp2' must be 'comp'.");
-                        const f1 = (comp1 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
-                        const f2 = (comp2 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
-                        const g = [
-                            (a: number, b: number) => {
-                                const d = f2[0](a, b) * f2[0](a, b) + f2[1](a, b) * f2[1](a, b);
-                                return (f1[0](a, b) * f2[0](a, b) + f1[1](a, b) * f2[1](a, b)) / d;
-                            },
-                            (a: number, b: number) => {
-                                const d = f2[0](a, b) * f2[0](a, b) + f2[1](a, b) * f2[1](a, b);
-                                return (f1[1](a, b) * f2[0](a, b) - f1[0](a, b) * f2[1](a, b)) / d;
-                            }
-                        ];
-                        return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
-                    } else {
-                        const f = (comp1 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
-                        const z = comp2 as ChalkboardComplex;
-                        const d = z.a * z.a + z.b * z.b;
-                        const g = [
-                            (a: number, b: number) => (f[0](a, b) * z.a + f[1](a, b) * z.b) / d,
-                            (a: number, b: number) => (f[1](a, b) * z.a - f[0](a, b) * z.b) / d
-                        ];
-                        return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+                if ((comp1 as ChalkboardFunction).field !== "comp" || (comp2 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.div: Properties 'field' of 'comp1' and 'comp2' must be 'comp'.");
+                const f1 = (comp1 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const f2 = (comp2 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const g = [
+                    (a: number, b: number) => {
+                        const d = f2[0](a, b) * f2[0](a, b) + f2[1](a, b) * f2[1](a, b);
+                        return (f1[0](a, b) * f2[0](a, b) + f1[1](a, b) * f2[1](a, b)) / d;
+                    },
+                    (a: number, b: number) => {
+                        const d = f2[0](a, b) * f2[0](a, b) + f2[1](a, b) * f2[1](a, b);
+                        return (f1[1](a, b) * f2[0](a, b) - f1[0](a, b) * f2[1](a, b)) / d;
                     }
-                } else {
-                    if ((comp2 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.div: Property 'field' of 'comp2' must be 'comp'.");
-                    const z = comp1 as ChalkboardComplex;
-                    const f = (comp2 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
-                    const g = [
-                        (a: number, b: number) => {
-                            const d = f[0](a, b) * f[0](a, b) + f[1](a, b) * f[1](a, b);
-                            return (z.a * f[0](a, b) + z.b * f[1](a, b)) / d;
-                        },
-                        (a: number, b: number) => {
-                            const d = f[0](a, b) * f[0](a, b) + f[1](a, b) * f[1](a, b);
-                            return (z.b * f[0](a, b) - z.a * f[1](a, b)) / d;
-                        }
-                    ];
-                    return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
-                }
+                ];
+                return Chalkboard.comp.define(...g);
             }
             throw new TypeError("Chalkboard.comp.div: Parameters 'comp1' and 'comp2' must be of type ChalkboardComplex, number, or ChalkboardFunction.");
         };
@@ -392,27 +350,11 @@ namespace Chalkboard {
                 const z2 = comp2 as ChalkboardComplex;
                 return Chalkboard.comp.init(z1.a * z2.a - z1.b * z2.b, z1.a * z2.b + z1.b * z2.a);
             } else if (comp1.hasOwnProperty("rule") || comp2.hasOwnProperty("rule")) {
-                if (comp1.hasOwnProperty("rule")) {
-                    if ((comp1 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.mul: Property 'field' of 'comp1' must be 'comp'.");
-                    if (comp2.hasOwnProperty("rule")) {
-                        if ((comp2 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.mul: Property 'field' of 'comp2' must be 'comp'.");
-                        const f1 = (comp1 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
-                        const f2 = (comp2 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
-                        const g = [(a: number, b: number) => f1[0](a, b) * f2[0](a, b) - f1[1](a, b) * f2[1](a, b), (a: number, b: number) => f1[0](a, b) * f2[1](a, b) + f1[1](a, b) * f2[0](a, b)];
-                        return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
-                    } else {
-                        const f = (comp1 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
-                        const z = comp2 as ChalkboardComplex;
-                        const g = [(a: number, b: number) => f[0](a, b) * z.a - f[1](a, b) * z.b, (a: number, b: number) => f[0](a, b) * z.b + f[1](a, b) * z.a];
-                        return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
-                    }
-                } else {
-                    if ((comp2 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.mul: Property 'field' of 'comp2' must be 'comp'.");
-                    const z = comp1 as ChalkboardComplex;
-                    const f = (comp2 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
-                    const g = [(a: number, b: number) => z.a * f[0](a, b) - z.b * f[1](a, b), (a: number, b: number) => z.a * f[1](a, b) + z.b * f[0](a, b)];
-                    return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
-                }
+                if ((comp1 as ChalkboardFunction).field !== "comp" || (comp2 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.mul: Properties 'field' of 'comp1' and 'comp2' must be 'comp'.");
+                const f1 = (comp1 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const f2 = (comp2 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const g = [(a: number, b: number) => f1[0](a, b) * f2[0](a, b) - f1[1](a, b) * f2[1](a, b), (a: number, b: number) => f1[0](a, b) * f2[1](a, b) + f1[1](a, b) * f2[0](a, b)];
+                return Chalkboard.comp.define(...g);
             }
             throw new TypeError("Chalkboard.comp.mul: Parameters 'comp1' and 'comp2' must be of type ChalkboardComplex, number, or ChalkboardFunction.");
         };
@@ -432,9 +374,9 @@ namespace Chalkboard {
                 return Chalkboard.comp.init(-z.a, -z.b);
             } else if (comp.hasOwnProperty("rule")) {
                 if ((comp as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.negate: Property 'field' of 'comp' must be 'comp'.");
-                const f = (comp as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const f = (comp as ChalkboardFunction).rule as ((a: number, b: number) => number)[];
                 const g = [(a: number, b: number) => -f[0](a, b), (a: number, b: number) => -f[1](a, b)];
-                return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+                return Chalkboard.comp.define(...g);
             }
             throw new TypeError("Chalkboard.comp.negate: Parameter 'comp' must be of type ChalkboardComplex, number, or ChalkboardFunction.");
         };
@@ -484,20 +426,20 @@ namespace Chalkboard {
                 );
             } else if (comp.hasOwnProperty("rule")) {
                 if ((comp as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.pow: Property 'field' of 'comp' must be 'comp'.");
-                const f = (comp as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const f = (comp as ChalkboardFunction).rule as ((a: number, b: number) => number)[];
                 const g = [
                     (a: number, b: number) => {
-                        const mag = Math.sqrt(f[0](a, b) * f[0](a, b) + f[1](a, b) * f[1](a, b));
-                        const arg = Math.atan2(f[1](a, b), f[0](a, b));
-                        return Math.pow(mag, num) * Math.cos(num * arg);
+                        const mag = Chalkboard.real.sqrt(f[0](a, b) * f[0](a, b) + f[1](a, b) * f[1](a, b));
+                        const arg = Chalkboard.trig.arctan2(f[1](a, b), f[0](a, b));
+                        return (Chalkboard.real.pow(mag, num) as number) * Chalkboard.trig.cos(num * arg);
                     },
                     (a: number, b: number) => {
-                        const mag = Math.sqrt(f[0](a, b) * f[0](a, b) + f[1](a, b) * f[1](a, b));
-                        const arg = Math.atan2(f[1](a, b), f[0](a, b));
-                        return Math.pow(mag, num) * Math.sin(num * arg);
+                        const mag = Chalkboard.real.sqrt(f[0](a, b) * f[0](a, b) + f[1](a, b) * f[1](a, b));
+                        const arg = Chalkboard.trig.arctan2(f[1](a, b), f[0](a, b));
+                        return (Chalkboard.real.pow(mag, num) as number) * Chalkboard.trig.sin(num * arg);
                     }
                 ];
-                return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+                return Chalkboard.comp.define(...g);
             }
             throw new TypeError("Chalkboard.comp.pow: Parameter 'comp' must be of type ChalkboardComplex, number, or ChalkboardFunction.");
         };
@@ -558,9 +500,9 @@ namespace Chalkboard {
                 return Chalkboard.comp.init(1 / z.a, 1 / z.b);
             } else if (comp.hasOwnProperty("rule")) {
                 if ((comp as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.reciprocate: Property 'field' of 'comp' must be 'comp'.");
-                const f = (comp as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const f = (comp as ChalkboardFunction).rule as ((a: number, b: number) => number)[];
                 const g = [(a: number, b: number) => 1 / f[0](a, b), (a: number, b: number) => 1 / f[1](a, b)];
-                return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+                return Chalkboard.comp.define(...g);
             }
             throw new TypeError("Chalkboard.comp.reciprocate: Parameter 'comp' must be of type ChalkboardComplex, number, or ChalkboardFunction.");
         };
@@ -633,9 +575,9 @@ namespace Chalkboard {
                 return Chalkboard.comp.init(z.a * num, z.b * num);
             } else if (comp.hasOwnProperty("rule")) {
                 if ((comp as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.scl: Property 'field' of 'comp' must be 'comp'.");
-                const f = (comp as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const f = (comp as ChalkboardFunction).rule as ((a: number, b: number) => number)[];
                 const g = [(a: number, b: number) => f[0](a, b) * num, (a: number, b: number) => f[1](a, b) * num];
-                return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+                return Chalkboard.comp.define(...g);
             }
             throw new TypeError("Chalkboard.comp.scl: Parameter 'comp' must be of type ChalkboardComplex, number, or ChalkboardFunction.");
         };
@@ -667,9 +609,9 @@ namespace Chalkboard {
                 return Chalkboard.comp.init(z.a * z.a - z.b * z.b, 2 * z.a * z.b);
             } else if (comp.hasOwnProperty("rule")) {
                 if ((comp as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.sq: Property 'field' of 'comp' must be 'comp'.");
-                const f = (comp as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const f = (comp as ChalkboardFunction).rule as ((a: number, b: number) => number)[];
                 const g = [(a: number, b: number) => f[0](a, b) * f[0](a, b) - f[1](a, b) * f[1](a, b), (a: number, b: number) => 2 * f[0](a, b) * f[1](a, b)];
-                return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+                return Chalkboard.comp.define(...g);
             }
             throw new TypeError("Chalkboard.comp.sq: Parameter 'comp' must be of type ChalkboardComplex, number, or ChalkboardFunction.");
         };
@@ -692,20 +634,20 @@ namespace Chalkboard {
                 );
             } else if (comp.hasOwnProperty("rule")) {
                 if ((comp as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.sqrt: Property 'field' of 'comp' must be 'comp'.");
-                const f = (comp as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const f = (comp as ChalkboardFunction).rule as ((a: number, b: number) => number)[];
                 const g = [
                     (a: number, b: number) => {
                         const re = f[0](a, b);
                         const im = f[1](a, b);
-                        return Math.sqrt((re + Math.sqrt(re * re + im * im)) / 2);
+                        return Chalkboard.real.sqrt((re + Chalkboard.real.sqrt(re * re + im * im)) / 2);
                     },
                     (a: number, b: number) => {
                         const re = f[0](a, b);
                         const im = f[1](a, b);
-                        return Math.sign(im) * Math.sqrt((-re + Math.sqrt(re * re + im * im)) / 2);
+                        return Chalkboard.numb.sgn(im) * Chalkboard.real.sqrt((-re + Chalkboard.real.sqrt(re * re + im * im)) / 2);
                     }
                 ];
-                return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+                return Chalkboard.comp.define(...g);
             }
             throw new TypeError("Chalkboard.comp.sqrt: Parameter 'comp' must be of type ChalkboardComplex, number, or ChalkboardFunction.");
         };
@@ -727,27 +669,11 @@ namespace Chalkboard {
                 const z2 = comp2 as ChalkboardComplex;
                 return Chalkboard.comp.init(z1.a - z2.a, z1.b - z2.b);
             } else if (comp1.hasOwnProperty("rule") || comp2.hasOwnProperty("rule")) {
-                if (comp1.hasOwnProperty("rule")) {
-                    if ((comp1 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.sub: Property 'field' of 'comp1' must be 'comp'.");
-                    if (comp2.hasOwnProperty("rule")) {
-                        if ((comp2 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.sub: Property 'field' of 'comp2' must be 'comp'.");
-                        const f1 = (comp1 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
-                        const f2 = (comp2 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
-                        const g = [(a: number, b: number) => f1[0](a, b) - f2[0](a, b), (a: number, b: number) => f1[1](a, b) - f2[1](a, b)];
-                        return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
-                    } else {
-                        const f = (comp1 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
-                        const z = comp2 as ChalkboardComplex;
-                        const g = [(a: number, b: number) => f[0](a, b) - z.a, (a: number, b: number) => f[1](a, b) - z.b];
-                        return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
-                    }
-                } else {
-                    if ((comp2 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.sub: Property 'field' of 'comp2' must be 'comp'.");
-                    const z = comp1 as ChalkboardComplex;
-                    const f = (comp2 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
-                    const g = [(a: number, b: number) => z.a - f[0](a, b), (a: number, b: number) => z.b - f[1](a, b)];
-                    return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
-                }
+                if ((comp1 as ChalkboardFunction).field !== "comp" || (comp2 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.sub: Properties 'field' of 'comp1' and 'comp2' must be 'comp'.");
+                const f1 = (comp1 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const f2 = (comp2 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const g = [(a: number, b: number) => f1[0](a, b) - f2[0](a, b), (a: number, b: number) => f1[1](a, b) - f2[1](a, b)];
+                return Chalkboard.comp.define(...g);
             }
             throw new TypeError("Chalkboard.comp.sub: Parameters 'comp1' and 'comp2' must be of type ChalkboardComplex, number, or ChalkboardFunction.");
         };
@@ -851,10 +777,7 @@ namespace Chalkboard {
          * @returns {ChalkboardComplex}
          * @example
          * // Returns 3 + 4i
-         * const f = Chalkboard.comp.define(
-         *     (a, b) => a*a - b*b,
-         *     (a, b) => 2*a*b
-         * );
+         * const f = Chalkboard.comp.define((z) => Chalkboard.comp.sq(z));
          * const z = Chalkboard.comp.val(f, Chalkboard.comp.init(2, 1));
          */
         export const val = (func: ChalkboardFunction, comp: ChalkboardComplex): ChalkboardComplex => {

--- a/src/Chalkboard-comp.ts
+++ b/src/Chalkboard-comp.ts
@@ -10,30 +10,67 @@ namespace Chalkboard {
      */
     export namespace comp {
         /**
-         * Calculates the absolute value of a complex number.
-         * @param {ChalkboardComplex} comp - The complex number
-         * @returns {ChalkboardComplex}
+         * Calculates the absolute value of a complex number or complex function.
+         * @param {ChalkboardComplex | number | ChalkboardFunction} comp - The complex number or function
+         * @returns {ChalkboardComplex | ChalkboardFunction}
          * @example
          * // Returns 2 + 3i
          * const z = Chalkboard.comp.absolute(Chalkboard.comp.init(-2, 3));
          */
-        export const absolute = (comp: ChalkboardComplex): ChalkboardComplex => {
-            return Chalkboard.comp.init(Math.abs(comp.a), Math.abs(comp.b));
+        export const absolute = (comp: ChalkboardComplex | number | ChalkboardFunction): ChalkboardComplex | ChalkboardFunction => {
+            if (typeof comp === "number") comp = Chalkboard.comp.init(comp, 0);
+            if (comp.hasOwnProperty("a") && comp.hasOwnProperty("b")) {
+                const z = comp as ChalkboardComplex;
+                return Chalkboard.comp.init(Math.abs(z.a), Math.abs(z.b));
+            } else if (comp.hasOwnProperty("rule")) {
+                if ((comp as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.absolute: Property 'field' of 'comp' must be 'comp'.");
+                const f = (comp as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const g = [(a: number, b: number) => Math.abs(f[0](a, b)), (a: number, b: number) => Math.abs(f[1](a, b))];
+                return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+            }
+            throw new TypeError("Chalkboard.comp.absolute: Parameter 'comp' must be of type ChalkboardComplex, number, or ChalkboardFunction.");
         };
 
         /**
-         * Calculates the addition of two complex numbers.
-         * @param {ChalkboardComplex | number} comp1 - The first complex number
-         * @param {ChalkboardComplex | number} comp2 - The second complex number
-         * @returns {ChalkboardComplex}
+         * Calculates the addition of two complex numbers or functions.
+         * @param {ChalkboardComplex | number | ChalkboardFunction} comp1 - The first complex number or function
+         * @param {ChalkboardComplex | number | ChalkboardFunction} comp2 - The second complex number or function
+         * @returns {ChalkboardComplex | ChalkboardFunction}
          * @example
          * // Returns 3 + 4i
          * const sum = Chalkboard.comp.add(Chalkboard.comp.init(2, 3), Chalkboard.comp.init(1, 1));
          */
-        export const add = (comp1: ChalkboardComplex | number, comp2: ChalkboardComplex | number): ChalkboardComplex => {
+        export const add = (comp1: ChalkboardComplex | number | ChalkboardFunction, comp2: ChalkboardComplex | number | ChalkboardFunction): ChalkboardComplex | ChalkboardFunction => {
             if (typeof comp1 === "number") comp1 = Chalkboard.comp.init(comp1, 0);
             if (typeof comp2 === "number") comp2 = Chalkboard.comp.init(comp2, 0);
-            return Chalkboard.comp.init(comp1.a + comp2.a, comp1.b + comp2.b);
+            if (comp1.hasOwnProperty("a") && comp1.hasOwnProperty("b") && comp2.hasOwnProperty("a") && comp2.hasOwnProperty("b")) {
+                const z1 = comp1 as ChalkboardComplex;
+                const z2 = comp2 as ChalkboardComplex;
+                return Chalkboard.comp.init(z1.a + z2.a, z1.b + z2.b);
+            } else if (comp1.hasOwnProperty("rule") || comp2.hasOwnProperty("rule")) {
+                if (comp1.hasOwnProperty("rule")) {
+                    if ((comp1 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.add: Property 'field' of 'comp1' must be 'comp'.");
+                    if (comp2.hasOwnProperty("rule")) {
+                        if ((comp2 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.add: Property 'field' of 'comp2' must be 'comp'.");
+                        const f1 = (comp1 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                        const f2 = (comp2 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                        const g = [(a: number, b: number) => f1[0](a, b) + f2[0](a, b), (a: number, b: number) => f1[1](a, b) + f2[1](a, b)];
+                        return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+                    } else {
+                        const f = (comp1 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                        const z = comp2 as ChalkboardComplex;
+                        const g = [(a: number, b: number) => f[0](a, b) + z.a, (a: number, b: number) => f[1](a, b) + z.b];
+                        return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+                    }
+                } else {
+                    if ((comp2 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.add: Property 'field' of 'comp2' must be 'comp'.");
+                    const z = comp1 as ChalkboardComplex;
+                    const f = (comp2 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                    const g = [(a: number, b: number) => z.a + f[0](a, b), (a: number, b: number) => z.b + f[1](a, b)];
+                    return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+                }
+            }
+            throw new TypeError("Chalkboard.comp.add: Parameters 'comp1' and 'comp2' must be of type ChalkboardComplex, number, or ChalkboardFunction.");
         };
 
         /**
@@ -62,15 +99,25 @@ namespace Chalkboard {
         };
 
         /**
-         * Calculates the conjugate of a complex number.
-         * @param {ChalkboardComplex} comp - The complex number
-         * @returns {ChalkboardComplex}
+         * Calculates the conjugate of a complex number or function.
+         * @param {ChalkboardComplex | number | ChalkboardFunction} comp - The complex number or function
+         * @returns {ChalkboardComplex | ChalkboardFunction}
          * @example
          * // Returns 2 - 3i
          * const conj = Chalkboard.comp.conjugate(Chalkboard.comp.init(2, 3));
          */
-        export const conjugate = (comp: ChalkboardComplex): ChalkboardComplex => {
-            return Chalkboard.comp.init(comp.a, -comp.b);
+        export const conjugate = (comp: ChalkboardComplex | number | ChalkboardFunction): ChalkboardComplex | ChalkboardFunction => {
+            if (typeof comp === "number") comp = Chalkboard.comp.init(comp, 0);
+            if (comp.hasOwnProperty("a") && comp.hasOwnProperty("b")) {
+                const z = comp as ChalkboardComplex;
+                return Chalkboard.comp.init(z.a, -z.b);
+            } else if (comp.hasOwnProperty("rule")) {
+                if ((comp as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.conjugate: Property 'field' of 'comp' must be 'comp'.");
+                const f = (comp as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const g = [(a: number, b: number) => f[0](a, b), (a: number, b: number) => -f[1](a, b)];
+                return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+            }
+            throw new TypeError("Chalkboard.comp.conjugate: Parameter 'comp' must be of type ChalkboardComplex, number, or ChalkboardFunction.");
         };
 
         /**
@@ -100,18 +147,34 @@ namespace Chalkboard {
 
         /**
          * Defines a complex function by its real part and imaginary part.
-         * @param {(a: number, b: number) => number} real
-         * @param {(a: number, b: number) => number} imaginary
+         * @param {Function | Function[]} rule - The rule of the function, which can be a single function that takes a complex number or an array of two functions that take real and imaginary parts respectively.
          * @returns {ChalkboardFunction}
          * @example
          * // Defines f(z) = z² or f(a+bi) = (a²-b²) + (2ab)i
-         * const f = Chalkboard.comp.define(
+         * const f = Chalkboard.comp.define((z) => Chalkboard.comp.sq(z));
+         * 
+         * // Defines g(a+bi) = (a²-b²) + (2ab)i or g(z) = z²
+         * const g = Chalkboard.comp.define([
          *     (a, b) => a*a - b*b,
          *     (a, b) => 2*a*b
-         * );
+         * ]);
          */
-        export const define = (real: (a: number, b: number) => number, imaginary: (a: number, b: number) => number): ChalkboardFunction => {
-            return { rule: [real, imaginary], field: "comp", type: "scalar3d" } as ChalkboardFunction;
+        export const define = (
+            rule: ((z: ChalkboardComplex) => ChalkboardComplex) | ([(a: number, b: number) => number, (a: number, b: number) => number])
+        ): ChalkboardFunction => {
+            if (Array.isArray(rule)) {
+                if (rule.length !== 2 || rule[0].length !== 2 || rule[1].length !== 2) throw new TypeError("Chalkboard.comp.define: If 'rule' is an array, it must be an array of two functions of two variables.");
+                if (typeof rule[0](0, 0) !== "number" || typeof rule[1](0, 0) !== "number") throw new TypeError("Chalkboard.comp.define: If 'rule' is an array, the functions in it must return real numbers.");
+                return { rule, field: "comp", type: "vector2d" } as ChalkboardFunction;
+            } else {
+                if (rule.length !== 1) throw new TypeError("Chalkboard.comp.define: If 'rule' is a function, it must be a function of one variable.");
+                if (!rule(Chalkboard.comp.init(0, 0)).hasOwnProperty("a") || !rule(Chalkboard.comp.init(0, 0)).hasOwnProperty("b")) throw new TypeError("Chalkboard.comp.define: If 'rule' is a function, it must return a complex number.");
+                const f = rule as (z: ChalkboardComplex) => ChalkboardComplex;
+                return { rule: [
+                    (a: number, b: number) => f(Chalkboard.comp.init(a, b)).a,
+                    (a: number, b: number) => f(Chalkboard.comp.init(a, b)).b
+                ], field: "comp", type: "vector2d" } as ChalkboardFunction;
+            }
         };
 
         /**
@@ -145,18 +208,68 @@ namespace Chalkboard {
         };
 
         /**
-         * Calculates the division of two complex numbers.
-         * @param {ChalkboardComplex | number} comp1 - The first complex number
-         * @param {ChalkboardComplex | number} comp2 - The second complex number
-         * @returns {ChalkboardComplex}
+         * Calculates the division of two complex numbers or functions.
+         * @param {ChalkboardComplex | number | ChalkboardFunction} comp1 - The first complex number or function
+         * @param {ChalkboardComplex | number | ChalkboardFunction} comp2 - The second complex number or function
+         * @returns {ChalkboardComplex | ChalkboardFunction}
          * @example
          * // Returns 0.44 + 0.08i (approximate)
          * const quotient = Chalkboard.comp.div(Chalkboard.comp.init(2, 1), Chalkboard.comp.init(4, 2));
          */
-        export const div = (comp1: ChalkboardComplex | number, comp2: ChalkboardComplex | number): ChalkboardComplex => {
+        export const div = (comp1: ChalkboardComplex | number | ChalkboardFunction, comp2: ChalkboardComplex | number | ChalkboardFunction): ChalkboardComplex | ChalkboardFunction => {
             if (typeof comp1 === "number") comp1 = Chalkboard.comp.init(comp1, 0);
             if (typeof comp2 === "number") comp2 = Chalkboard.comp.init(comp2, 0);
-            return Chalkboard.comp.init((comp1.a * comp2.a - comp1.b * comp2.b) / Chalkboard.comp.magsq(comp2), (comp1.b * comp2.a - comp1.a * comp2.b) / Chalkboard.comp.magsq(comp2));
+            if (comp1.hasOwnProperty("a") && comp1.hasOwnProperty("b") && comp2.hasOwnProperty("a") && comp2.hasOwnProperty("b")) {
+                const z1 = comp1 as ChalkboardComplex;
+                const z2 = comp2 as ChalkboardComplex;
+                const d = z2.a * z2.a + z2.b * z2.b;
+                return Chalkboard.comp.init((z1.a * z2.a + z1.b * z2.b) / d, (z1.b * z2.a - z1.a * z2.b) / d);
+            } else if (comp1.hasOwnProperty("rule") || comp2.hasOwnProperty("rule")) {
+                if (comp1.hasOwnProperty("rule")) {
+                    if ((comp1 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.div: Property 'field' of 'comp1' must be 'comp'.");
+                    if (comp2.hasOwnProperty("rule")) {
+                        if ((comp2 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.div: Property 'field' of 'comp2' must be 'comp'.");
+                        const f1 = (comp1 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                        const f2 = (comp2 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                        const g = [
+                            (a: number, b: number) => {
+                                const d = f2[0](a, b) * f2[0](a, b) + f2[1](a, b) * f2[1](a, b);
+                                return (f1[0](a, b) * f2[0](a, b) + f1[1](a, b) * f2[1](a, b)) / d;
+                            },
+                            (a: number, b: number) => {
+                                const d = f2[0](a, b) * f2[0](a, b) + f2[1](a, b) * f2[1](a, b);
+                                return (f1[1](a, b) * f2[0](a, b) - f1[0](a, b) * f2[1](a, b)) / d;
+                            }
+                        ];
+                        return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+                    } else {
+                        const f = (comp1 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                        const z = comp2 as ChalkboardComplex;
+                        const d = z.a * z.a + z.b * z.b;
+                        const g = [
+                            (a: number, b: number) => (f[0](a, b) * z.a + f[1](a, b) * z.b) / d,
+                            (a: number, b: number) => (f[1](a, b) * z.a - f[0](a, b) * z.b) / d
+                        ];
+                        return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+                    }
+                } else {
+                    if ((comp2 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.div: Property 'field' of 'comp2' must be 'comp'.");
+                    const z = comp1 as ChalkboardComplex;
+                    const f = (comp2 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                    const g = [
+                        (a: number, b: number) => {
+                            const d = f[0](a, b) * f[0](a, b) + f[1](a, b) * f[1](a, b);
+                            return (z.a * f[0](a, b) + z.b * f[1](a, b)) / d;
+                        },
+                        (a: number, b: number) => {
+                            const d = f[0](a, b) * f[0](a, b) + f[1](a, b) * f[1](a, b);
+                            return (z.b * f[0](a, b) - z.a * f[1](a, b)) / d;
+                        }
+                    ];
+                    return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+                }
+            }
+            throw new TypeError("Chalkboard.comp.div: Parameters 'comp1' and 'comp2' must be of type ChalkboardComplex, number, or ChalkboardFunction.");
         };
 
         /**
@@ -247,7 +360,7 @@ namespace Chalkboard {
          * const normscl = Chalkboard.comp.magset(Chalkboard.comp.init(3, 4), 10);
          */
         export const magset = (comp: ChalkboardComplex, num: number): ChalkboardComplex => {
-            return Chalkboard.comp.scl(Chalkboard.comp.normalize(comp), num);
+            return Chalkboard.comp.scl(Chalkboard.comp.normalize(comp), num) as ChalkboardComplex;
         };
 
         /**
@@ -263,30 +376,67 @@ namespace Chalkboard {
         };
 
         /**
-         * Calculates the multiplication of two complex numbers.
-         * @param {ChalkboardComplex | number} comp1 - The first complex number
-         * @param {ChalkboardComplex | number} comp2 - The second complex number
-         * @returns {ChalkboardComplex}
+         * Calculates the multiplication of two complex numbers or functions.
+         * @param {ChalkboardComplex | number | ChalkboardFunction} comp1 - The first complex number or function
+         * @param {ChalkboardComplex | number | ChalkboardFunction} comp2 - The second complex number or function
+         * @returns {ChalkboardComplex | ChalkboardFunction}
          * @example
          * // Returns -5 + 10i
          * const product = Chalkboard.comp.mul(Chalkboard.comp.init(2, 3), Chalkboard.comp.init(1, 2));
          */
-        export const mul = (comp1: ChalkboardComplex | number, comp2: ChalkboardComplex | number): ChalkboardComplex => {
+        export const mul = (comp1: ChalkboardComplex | number | ChalkboardFunction, comp2: ChalkboardComplex | number | ChalkboardFunction): ChalkboardComplex | ChalkboardFunction => {
             if (typeof comp1 === "number") comp1 = Chalkboard.comp.init(comp1, 0);
             if (typeof comp2 === "number") comp2 = Chalkboard.comp.init(comp2, 0);
-            return Chalkboard.comp.init(comp1.a * comp2.a - comp1.b * comp2.b, comp1.a * comp2.b + comp1.b * comp2.a);
+            if (comp1.hasOwnProperty("a") && comp1.hasOwnProperty("b") && comp2.hasOwnProperty("a") && comp2.hasOwnProperty("b")) {
+                const z1 = comp1 as ChalkboardComplex;
+                const z2 = comp2 as ChalkboardComplex;
+                return Chalkboard.comp.init(z1.a * z2.a - z1.b * z2.b, z1.a * z2.b + z1.b * z2.a);
+            } else if (comp1.hasOwnProperty("rule") || comp2.hasOwnProperty("rule")) {
+                if (comp1.hasOwnProperty("rule")) {
+                    if ((comp1 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.mul: Property 'field' of 'comp1' must be 'comp'.");
+                    if (comp2.hasOwnProperty("rule")) {
+                        if ((comp2 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.mul: Property 'field' of 'comp2' must be 'comp'.");
+                        const f1 = (comp1 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                        const f2 = (comp2 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                        const g = [(a: number, b: number) => f1[0](a, b) * f2[0](a, b) - f1[1](a, b) * f2[1](a, b), (a: number, b: number) => f1[0](a, b) * f2[1](a, b) + f1[1](a, b) * f2[0](a, b)];
+                        return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+                    } else {
+                        const f = (comp1 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                        const z = comp2 as ChalkboardComplex;
+                        const g = [(a: number, b: number) => f[0](a, b) * z.a - f[1](a, b) * z.b, (a: number, b: number) => f[0](a, b) * z.b + f[1](a, b) * z.a];
+                        return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+                    }
+                } else {
+                    if ((comp2 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.mul: Property 'field' of 'comp2' must be 'comp'.");
+                    const z = comp1 as ChalkboardComplex;
+                    const f = (comp2 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                    const g = [(a: number, b: number) => z.a * f[0](a, b) - z.b * f[1](a, b), (a: number, b: number) => z.a * f[1](a, b) + z.b * f[0](a, b)];
+                    return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+                }
+            }
+            throw new TypeError("Chalkboard.comp.mul: Parameters 'comp1' and 'comp2' must be of type ChalkboardComplex, number, or ChalkboardFunction.");
         };
 
         /**
-         * Calculates the negation a complex number.
-         * @param {ChalkboardComplex} comp - The complex number
-         * @returns {ChalkboardComplex}
+         * Calculates the negation of a complex number or function.
+         * @param {ChalkboardComplex | number | ChalkboardFunction} comp - The complex number or function
+         * @returns {ChalkboardComplex | ChalkboardFunction}
          * @example
          * // Returns -2 - 3i
          * const negated = Chalkboard.comp.negate(Chalkboard.comp.init(2, 3));
          */
-        export const negate = (comp: ChalkboardComplex): ChalkboardComplex => {
-            return Chalkboard.comp.init(-comp.a, -comp.b);
+        export const negate = (comp: ChalkboardComplex | number | ChalkboardFunction): ChalkboardComplex | ChalkboardFunction => {
+            if (typeof comp === "number") comp = Chalkboard.comp.init(comp, 0);
+            if (comp.hasOwnProperty("a") && comp.hasOwnProperty("b")) {
+                const z = comp as ChalkboardComplex;
+                return Chalkboard.comp.init(-z.a, -z.b);
+            } else if (comp.hasOwnProperty("rule")) {
+                if ((comp as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.negate: Property 'field' of 'comp' must be 'comp'.");
+                const f = (comp as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const g = [(a: number, b: number) => -f[0](a, b), (a: number, b: number) => -f[1](a, b)];
+                return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+            }
+            throw new TypeError("Chalkboard.comp.negate: Parameter 'comp' must be of type ChalkboardComplex, number, or ChalkboardFunction.");
         };
 
         /**
@@ -314,19 +464,42 @@ namespace Chalkboard {
         };
 
         /**
-         * Calculates the exponentiation of a complex number.
-         * @param {ChalkboardComplex} comp - The complex number
+         * Calculates the exponentiation of a complex number or function.
+         * @param {ChalkboardComplex | number | ChalkboardFunction} comp - The complex number or function
          * @param {number} num - The exponent
-         * @returns {ChalkboardComplex}
+         * @returns {ChalkboardComplex | ChalkboardFunction}
          * @example
          * // Returns -11 + 2i
          * const pow = Chalkboard.comp.pow(Chalkboard.comp.init(2, 1), 3);
          */
-        export const pow = (comp: ChalkboardComplex, num: number): ChalkboardComplex => {
-            return Chalkboard.comp.init(
-                Chalkboard.real.pow(Chalkboard.comp.mag(comp), num) as number * Chalkboard.trig.cos(num * Chalkboard.comp.arg(comp)),
-                Chalkboard.real.pow(Chalkboard.comp.mag(comp), num) as number * Chalkboard.trig.sin(num * Chalkboard.comp.arg(comp))
-            );
+        export const pow = (comp: ChalkboardComplex | number | ChalkboardFunction, num: number): ChalkboardComplex | ChalkboardFunction => {
+            if (typeof comp === "number") comp = Chalkboard.comp.init(comp, 0);
+            if (comp.hasOwnProperty("a") && comp.hasOwnProperty("b")) {
+                const z = comp as ChalkboardComplex;
+                const mag = Chalkboard.comp.mag(z);
+                const arg = Chalkboard.comp.arg(z);
+                return Chalkboard.comp.init(
+                    (Chalkboard.real.pow(mag, num) as number) * Chalkboard.trig.cos(num * arg),
+                    (Chalkboard.real.pow(mag, num) as number) * Chalkboard.trig.sin(num * arg)
+                );
+            } else if (comp.hasOwnProperty("rule")) {
+                if ((comp as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.pow: Property 'field' of 'comp' must be 'comp'.");
+                const f = (comp as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const g = [
+                    (a: number, b: number) => {
+                        const mag = Math.sqrt(f[0](a, b) * f[0](a, b) + f[1](a, b) * f[1](a, b));
+                        const arg = Math.atan2(f[1](a, b), f[0](a, b));
+                        return Math.pow(mag, num) * Math.cos(num * arg);
+                    },
+                    (a: number, b: number) => {
+                        const mag = Math.sqrt(f[0](a, b) * f[0](a, b) + f[1](a, b) * f[1](a, b));
+                        const arg = Math.atan2(f[1](a, b), f[0](a, b));
+                        return Math.pow(mag, num) * Math.sin(num * arg);
+                    }
+                ];
+                return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+            }
+            throw new TypeError("Chalkboard.comp.pow: Parameter 'comp' must be of type ChalkboardComplex, number, or ChalkboardFunction.");
         };
 
         /**
@@ -371,15 +544,25 @@ namespace Chalkboard {
         };
 
         /**
-         * Calculates the reciprocal of a complex number.
-         * @param {ChalkboardComplex} comp - The complex number
-         * @returns {ChalkboardComplex}
+         * Calculates the reciprocal of a complex number or function.
+         * @param {ChalkboardComplex | number | ChalkboardFunction} comp - The complex number or function
+         * @returns {ChalkboardComplex | ChalkboardFunction}
          * @example
          * // Returns 0.5 + 0.3333i
          * const reciprocated = Chalkboard.comp.reciprocate(Chalkboard.comp.init(2, 3));
          */
-        export const reciprocate = (comp: ChalkboardComplex): ChalkboardComplex => {
-            return Chalkboard.comp.init(1 / comp.a, 1 / comp.b);
+        export const reciprocate = (comp: ChalkboardComplex | number | ChalkboardFunction): ChalkboardComplex | ChalkboardFunction => {
+            if (typeof comp === "number") comp = Chalkboard.comp.init(comp, 0);
+            if (comp.hasOwnProperty("a") && comp.hasOwnProperty("b")) {
+                const z = comp as ChalkboardComplex;
+                return Chalkboard.comp.init(1 / z.a, 1 / z.b);
+            } else if (comp.hasOwnProperty("rule")) {
+                if ((comp as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.reciprocate: Property 'field' of 'comp' must be 'comp'.");
+                const f = (comp as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const g = [(a: number, b: number) => 1 / f[0](a, b), (a: number, b: number) => 1 / f[1](a, b)];
+                return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+            }
+            throw new TypeError("Chalkboard.comp.reciprocate: Parameter 'comp' must be of type ChalkboardComplex, number, or ChalkboardFunction.");
         };
 
         /**
@@ -435,16 +618,26 @@ namespace Chalkboard {
         };
 
         /**
-         * Calculates the scalar multiplication of a complex number.
-         * @param {ChalkboardComplex} comp - The complex number
+         * Calculates the scalar multiplication of a complex number or function.
+         * @param {ChalkboardComplex | number | ChalkboardFunction} comp - The complex number or function
          * @param {number} num - The scalar
-         * @returns {ChalkboardComplex}
+         * @returns {ChalkboardComplex | ChalkboardFunction}
          * @example
          * // Returns 6 + 9i
          * const scaled = Chalkboard.comp.scl(Chalkboard.comp.init(2, 3), 3);
          */
-        export const scl = (comp: ChalkboardComplex, num: number): ChalkboardComplex => {
-            return Chalkboard.comp.init(comp.a * num, comp.b * num);
+        export const scl = (comp: ChalkboardComplex | number | ChalkboardFunction, num: number): ChalkboardComplex | ChalkboardFunction => {
+            if (typeof comp === "number") comp = Chalkboard.comp.init(comp, 0);
+            if (comp.hasOwnProperty("a") && comp.hasOwnProperty("b")) {
+                const z = comp as ChalkboardComplex;
+                return Chalkboard.comp.init(z.a * num, z.b * num);
+            } else if (comp.hasOwnProperty("rule")) {
+                if ((comp as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.scl: Property 'field' of 'comp' must be 'comp'.");
+                const f = (comp as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const g = [(a: number, b: number) => f[0](a, b) * num, (a: number, b: number) => f[1](a, b) * num];
+                return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+            }
+            throw new TypeError("Chalkboard.comp.scl: Parameter 'comp' must be of type ChalkboardComplex, number, or ChalkboardFunction.");
         };
 
         /**
@@ -460,45 +653,103 @@ namespace Chalkboard {
         };
 
         /**
-         * Calculates the square of a complex number.
-         * @param {ChalkboardComplex} comp - The complex number
-         * @returns {ChalkboardComplex}
+         * Calculates the square of a complex number or function.
+         * @param {ChalkboardComplex | number | ChalkboardFunction} comp - The complex number or function
+         * @returns {ChalkboardComplex | ChalkboardFunction}
          * @example
          * // Returns -5 + 12i
          * const sq = Chalkboard.comp.sq(Chalkboard.comp.init(3, 2));
          */
-        export const sq = (comp: ChalkboardComplex): ChalkboardComplex => {
-            return Chalkboard.comp.init(comp.a * comp.a - comp.b * comp.b, 2 * comp.a * comp.b);
+        export const sq = (comp: ChalkboardComplex | number | ChalkboardFunction): ChalkboardComplex | ChalkboardFunction => {
+            if (typeof comp === "number") comp = Chalkboard.comp.init(comp, 0);
+            if (comp.hasOwnProperty("a") && comp.hasOwnProperty("b")) {
+                const z = comp as ChalkboardComplex;
+                return Chalkboard.comp.init(z.a * z.a - z.b * z.b, 2 * z.a * z.b);
+            } else if (comp.hasOwnProperty("rule")) {
+                if ((comp as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.sq: Property 'field' of 'comp' must be 'comp'.");
+                const f = (comp as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const g = [(a: number, b: number) => f[0](a, b) * f[0](a, b) - f[1](a, b) * f[1](a, b), (a: number, b: number) => 2 * f[0](a, b) * f[1](a, b)];
+                return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+            }
+            throw new TypeError("Chalkboard.comp.sq: Parameter 'comp' must be of type ChalkboardComplex, number, or ChalkboardFunction.");
         };
 
         /**
-         * Calculates the square root of a complex number.
-         * @param {ChalkboardComplex} comp - The complex number
-         * @returns {ChalkboardComplex}
+         * Calculates the square root of a complex number or function.
+         * @param {ChalkboardComplex | number | ChalkboardFunction} comp - The complex number or function
+         * @returns {ChalkboardComplex | ChalkboardFunction}
          * @example
          * // Returns 2 + 0.5i
          * const sqrt = Chalkboard.comp.sqrt(Chalkboard.comp.init(4, 2));
          */
-        export const sqrt = (comp: ChalkboardComplex): ChalkboardComplex => {
-            return Chalkboard.comp.init(
-                Chalkboard.real.sqrt((comp.a + Chalkboard.real.sqrt(comp.a * comp.a + comp.b * comp.b)) / 2),
-                Chalkboard.numb.sgn(comp.b) * Chalkboard.real.sqrt((-comp.a + Chalkboard.real.sqrt(comp.a * comp.a + comp.b * comp.b)) / 2)
-            );
+        export const sqrt = (comp: ChalkboardComplex | number | ChalkboardFunction): ChalkboardComplex | ChalkboardFunction => {
+            if (typeof comp === "number") comp = Chalkboard.comp.init(comp, 0);
+            if (comp.hasOwnProperty("a") && comp.hasOwnProperty("b")) {
+                const z = comp as ChalkboardComplex;
+                return Chalkboard.comp.init(
+                    Chalkboard.real.sqrt((z.a + Chalkboard.real.sqrt(z.a * z.a + z.b * z.b)) / 2),
+                    Chalkboard.numb.sgn(z.b) * Chalkboard.real.sqrt((-z.a + Chalkboard.real.sqrt(z.a * z.a + z.b * z.b)) / 2)
+                );
+            } else if (comp.hasOwnProperty("rule")) {
+                if ((comp as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.sqrt: Property 'field' of 'comp' must be 'comp'.");
+                const f = (comp as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                const g = [
+                    (a: number, b: number) => {
+                        const re = f[0](a, b);
+                        const im = f[1](a, b);
+                        return Math.sqrt((re + Math.sqrt(re * re + im * im)) / 2);
+                    },
+                    (a: number, b: number) => {
+                        const re = f[0](a, b);
+                        const im = f[1](a, b);
+                        return Math.sign(im) * Math.sqrt((-re + Math.sqrt(re * re + im * im)) / 2);
+                    }
+                ];
+                return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+            }
+            throw new TypeError("Chalkboard.comp.sqrt: Parameter 'comp' must be of type ChalkboardComplex, number, or ChalkboardFunction.");
         };
 
         /**
-         * Calculates the subtraction of two complex numbers.
-         * @param {ChalkboardComplex | number} comp1 - The first complex number
-         * @param {ChalkboardComplex | number} comp2 - The second complex number
-         * @returns {ChalkboardComplex}
+         * Calculates the subtraction of two complex numbers or functions.
+         * @param {ChalkboardComplex | number | ChalkboardFunction} comp1 - The first complex number or function
+         * @param {ChalkboardComplex | number | ChalkboardFunction} comp2 - The second complex number or function
+         * @returns {ChalkboardComplex | ChalkboardFunction}
          * @example
          * // Returns 1 - 1i
          * const difference = Chalkboard.comp.sub(Chalkboard.comp.init(3, 2), Chalkboard.comp.init(2, 3));
          */
-        export const sub = (comp1: ChalkboardComplex | number, comp2: ChalkboardComplex | number): ChalkboardComplex => {
+        export const sub = (comp1: ChalkboardComplex | number | ChalkboardFunction, comp2: ChalkboardComplex | number | ChalkboardFunction): ChalkboardComplex | ChalkboardFunction => {
             if (typeof comp1 === "number") comp1 = Chalkboard.comp.init(comp1, 0);
             if (typeof comp2 === "number") comp2 = Chalkboard.comp.init(comp2, 0);
-            return Chalkboard.comp.init(comp1.a - comp2.a, comp1.b - comp2.b);
+            if (comp1.hasOwnProperty("a") && comp1.hasOwnProperty("b") && comp2.hasOwnProperty("a") && comp2.hasOwnProperty("b")) {
+                const z1 = comp1 as ChalkboardComplex;
+                const z2 = comp2 as ChalkboardComplex;
+                return Chalkboard.comp.init(z1.a - z2.a, z1.b - z2.b);
+            } else if (comp1.hasOwnProperty("rule") || comp2.hasOwnProperty("rule")) {
+                if (comp1.hasOwnProperty("rule")) {
+                    if ((comp1 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.sub: Property 'field' of 'comp1' must be 'comp'.");
+                    if (comp2.hasOwnProperty("rule")) {
+                        if ((comp2 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.sub: Property 'field' of 'comp2' must be 'comp'.");
+                        const f1 = (comp1 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                        const f2 = (comp2 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                        const g = [(a: number, b: number) => f1[0](a, b) - f2[0](a, b), (a: number, b: number) => f1[1](a, b) - f2[1](a, b)];
+                        return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+                    } else {
+                        const f = (comp1 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                        const z = comp2 as ChalkboardComplex;
+                        const g = [(a: number, b: number) => f[0](a, b) - z.a, (a: number, b: number) => f[1](a, b) - z.b];
+                        return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+                    }
+                } else {
+                    if ((comp2 as ChalkboardFunction).field !== "comp") throw new TypeError("Chalkboard.comp.sub: Property 'field' of 'comp2' must be 'comp'.");
+                    const z = comp1 as ChalkboardComplex;
+                    const f = (comp2 as ChalkboardFunction).rule as [(a: number, b: number) => number, (a: number, b: number) => number];
+                    const g = [(a: number, b: number) => z.a - f[0](a, b), (a: number, b: number) => z.b - f[1](a, b)];
+                    return Chalkboard.comp.define(g as [(a: number, b: number) => number, (a: number, b: number) => number]);
+                }
+            }
+            throw new TypeError("Chalkboard.comp.sub: Parameters 'comp1' and 'comp2' must be of type ChalkboardComplex, number, or ChalkboardFunction.");
         };
 
         /**
@@ -607,9 +858,7 @@ namespace Chalkboard {
          * const z = Chalkboard.comp.val(f, Chalkboard.comp.init(2, 1));
          */
         export const val = (func: ChalkboardFunction, comp: ChalkboardComplex): ChalkboardComplex => {
-            if (func.field !== "comp") {
-                throw new TypeError("Chalkboard.comp.val: Property 'field' of 'func' must be 'comp'.");
-            }
+            if (func.field !== "comp") throw new TypeError("Chalkboard.comp.val: Property 'field' of 'func' must be 'comp'.");
             const f = func.rule as [(a: number, b: number) => number, (a: number, b: number) => number];
             return Chalkboard.comp.init(f[0](comp.a, comp.b), f[1](comp.a, comp.b));
         };

--- a/src/Chalkboard-real.ts
+++ b/src/Chalkboard-real.ts
@@ -76,64 +76,60 @@ namespace Chalkboard {
         };
 
         /**
-         * Defines a real-valued mathematical function.
+         * Defines a mathematical function in the field of real numbers.
          * @param {Function | Function[]} rule - The rule(s) of the function
-         * @param {object} [config] - The configurable options of the function
-         * @param {string | string[]} [config.domain="R"] - The domain of the function (optional, automatically configured if not explicitly provided)
-         * @param {string | string[]} [config.codomain="R"] - The codomain of the function (optional, automatically configured if not explicitly provided)
-         * @param {"scalar2d" | "scalar3d" | "vector2d" | "vector3d" | "vector4d" | "curve2d" | "curve3d" | "surface"} [config.subtype] - The subtype of the function (optional, automatically configured if not explicitly provided)
+         * @param {"scalar2d" | "scalar3d" | "scalar4d" | "vector2d" | "vector3d" | "vector4d" | "curve2d" | "curve3d" | "curve4d" | "surface3d"} [type="scalar2d"] - The type of the function (optional, automatically configured if not explicitly provided)
          * @returns {ChalkboardFunction}
          */
         export const define = (
             rule: ((...x: number[]) => number) | (((...x: number[]) => number)[]),
-            config: {
-                domain?: string | string[],
-                codomain?: string | string[],
-                subtype?: "scalar2d" | "scalar3d" | "vector2d" | "vector3d" | "vector4d" | "curve2d" | "curve3d" | "surface"
-            } = {}
+            type: "scalar2d" | "scalar3d" | "scalar4d" | "vector2d" | "vector3d" | "vector4d" | "curve2d" | "curve3d" | "curve4d" | "surface3d" = "scalar2d"
         ): ChalkboardFunction => {
-            let domain = config.domain, codomain = config.codomain, subtype = config.subtype;
-            if (!domain || !codomain || !subtype) {
+            if (!type) {
                 if (Array.isArray(rule)) {
                     const f = rule[0];
                     if (rule.length === 2) {
                         if (f.length === 1) {
-                            domain = "R", codomain = ["R", "R"], subtype = "curve2d";
+                            type = "curve2d";
                         } else if (f.length === 2) {
-                            domain = ["R", "R"], codomain = ["R", "R"], subtype = "vector2d";
+                            type = "vector2d";
                         } else {
                             throw new Error("The function must have one variable to define a parametric curve or two variables to define a vector field.");
                         }
                     } else if (rule.length === 3) {
                         if (f.length === 1) {
-                            domain = "R", codomain = ["R", "R", "R"], subtype = "curve3d";
+                            type = "curve3d";
                         } else if (f.length === 2) {
-                            domain = ["R", "R"], codomain = ["R", "R", "R"], subtype = "surface";
+                            type = "surface3d";
                         } else if (f.length === 3) {
-                            domain = ["R", "R", "R"], codomain = ["R", "R", "R"], subtype = "vector3d";
+                            type = "vector3d";
                         } else {
                             throw new Error("The function must have one variable to define a parametric curve, two variables to define a parametric surface, or three variables to define a vector field.");
                         }
                     } else if (rule.length === 4) {
-                        if (f.length === 4) {
-                            domain = ["R", "R", "R", "R"], codomain = ["R", "R", "R", "R"], subtype = "vector4d";
+                        if (f.length === 1) {
+                            type = "curve4d";
+                        } else if (f.length === 4) {
+                            type = "vector4d";
                         } else {
-                            throw new Error("The function must have four variables to define a vector field.");
+                            throw new Error("The function must have one variable to define a parametric curve or four variables to define a vector field.");
                         }
                     }
                 } else {
                     const f = rule as (...x: number[]) => number;
                     if (f.length === 1) {
-                        domain = "R", codomain = "R", subtype = "scalar2d";
+                        type = "scalar2d";
                     } else if (f.length === 2) {
-                        domain = ["R", "R"], codomain = "R", subtype = "scalar3d";
+                        type = "scalar3d";
+                    } else if (f.length === 3) {
+                        type = "scalar4d";
                     } else {
-                        throw new Error("The function must have one or two variables to define a scalar function.");
+                        throw new Error("The function must have one, two, or three variables to define a scalar function.");
                     }
                 }
             }
-            domain = domain || "R", codomain = codomain || "R", subtype = subtype || "scalar2d";
-            return { rule, domain, codomain, type: "real", subtype } as ChalkboardFunction;
+            type = type || "scalar2d";
+            return { rule, field: "real", type } as ChalkboardFunction;
         };
 
         /**

--- a/src/Chalkboard-real.ts
+++ b/src/Chalkboard-real.ts
@@ -15,9 +15,7 @@ namespace Chalkboard {
          * @returns {ChalkboardFunction}
          */
         export const absolute = (func: ChalkboardFunction): ChalkboardFunction => {
-            if (func.field !== "real") {
-                throw new TypeError('Chalkboard.real.absolute: Property "field" of "func" must be "real".');
-            }
+            if (func.field !== "real") throw new TypeError("Chalkboard.real.absolute: Property 'field' of 'func' must be 'real'.");
             if (func.type.startsWith("scalar")) {
                 const f = func.rule as ((...x: number[]) => number);
                 const g = (...x: number[]) => Math.abs(f(...x));
@@ -44,7 +42,7 @@ namespace Chalkboard {
                 }
                 return Chalkboard.real.define(g, func.type);
             }
-            throw new TypeError('Chalkboard.real.absolute: Property "type" of "func" is not supported.');
+            throw new TypeError("Chalkboard.real.absolute: Property 'type' of 'func' must be 'scalar2d', 'scalar3d', 'scalar4d', 'vector2d', 'vector3d', 'vector4d', 'curve2d', 'curve3d', 'curve4d', or 'surface3d'.");
         };
 
         /**
@@ -54,12 +52,8 @@ namespace Chalkboard {
          * @returns {ChalkboardFunction}
          */
         export const add = (func1: ChalkboardFunction, func2: ChalkboardFunction): ChalkboardFunction => {
-            if (func1.field !== "real" || func2.field !== "real") {
-                throw new TypeError('Chalkboard.real.add: Properties "field" of "func1" and "func2" must be "real".');
-            }
-            if (func1.type !== func2.type) {
-                throw new TypeError('Chalkboard.real.add: Properties "type" of "func1" and "func2" must be the same.');
-            }
+            if (func1.field !== "real" || func2.field !== "real") throw new TypeError("Chalkboard.real.add: Properties 'field' of 'func1' and 'func2' must be 'real'.");
+            if (func1.type !== func2.type) throw new TypeError("Chalkboard.real.add: Properties 'type' of 'func1' and 'func2' must be the same.");
             if (func1.type.startsWith("scalar")) {
                 const f1 = func1.rule as ((...x: number[]) => number);
                 const f2 = func2.rule as ((...x: number[]) => number);
@@ -90,7 +84,7 @@ namespace Chalkboard {
                 }
                 return Chalkboard.real.define(g, func1.type);
             }
-            throw new TypeError('Chalkboard.real.add: Properties "type" of "func1" and "func2" are not supported.');
+            throw new TypeError("Chalkboard.real.add: Properties 'type' of 'func1' and 'func2' must be 'scalar2d', 'scalar3d', 'scalar4d', 'vector2d', 'vector3d', 'vector4d', 'curve2d', 'curve3d', 'curve4d', or 'surface3d'.");
         };
 
         /**
@@ -100,12 +94,8 @@ namespace Chalkboard {
          * @returns {ChalkboardFunction}
          */
         export const compose = (func1: ChalkboardFunction, func2: ChalkboardFunction): ChalkboardFunction => {
-            if (func1.field !== "real" || func2.field !== "real") {
-                throw new TypeError('Chalkboard.real.compose: Properties "field" of "func1" and "func2" must be "real".');
-            }
-            if (func1.type !== func2.type) {
-                throw new TypeError('Chalkboard.real.compose: Properties "type" of "func1" and "func2" must be the same.');
-            }
+            if (func1.field !== "real" || func2.field !== "real") throw new TypeError("Chalkboard.real.compose: Properties 'field' of 'func1' and 'func2' must be 'real'.");
+            if (func1.type !== func2.type) throw new TypeError("Chalkboard.real.compose: Properties 'type' of 'func1' and 'func2' must be the same.");
             if (func1.type.startsWith("scalar")) {
                 const f1 = func1.rule as ((...x: number[]) => number);
                 const f2 = func2.rule as ((...x: number[]) => number);
@@ -120,7 +110,7 @@ namespace Chalkboard {
                 }
                 return Chalkboard.real.define(g, func1.type);
             }
-            throw new TypeError('Chalkboard.real.compose: Properties "type" of "func1" and "func2" are not supported.');
+            throw new TypeError("Chalkboard.real.compose: Properties 'type' of 'func1' and 'func2' must be 'scalar2d', 'scalar3d', 'scalar4d', 'vector2d', 'vector3d', or 'vector4d'.");
         };
 
         /**
@@ -142,7 +132,7 @@ namespace Chalkboard {
                         } else if (f.length === 2) {
                             type = "vector2d";
                         } else {
-                            throw new Error("The function must have one variable to define a parametric curve or two variables to define a vector field.");
+                            throw new TypeError("Chalkboard.real.define: Functions in array 'rule' must have one variable to define a parametric curve or two variables to define a vector field.");
                         }
                     } else if (rule.length === 3) {
                         if (f.length === 1) {
@@ -152,7 +142,7 @@ namespace Chalkboard {
                         } else if (f.length === 3) {
                             type = "vector3d";
                         } else {
-                            throw new Error("The function must have one variable to define a parametric curve, two variables to define a parametric surface, or three variables to define a vector field.");
+                            throw new TypeError("Chalkboard.real.define: Functions in array 'rule' must have one variable to define a parametric curve, two variables to define a parametric surface, or three variables to define a vector field.");
                         }
                     } else if (rule.length === 4) {
                         if (f.length === 1) {
@@ -160,7 +150,7 @@ namespace Chalkboard {
                         } else if (f.length === 4) {
                             type = "vector4d";
                         } else {
-                            throw new Error("The function must have one variable to define a parametric curve or four variables to define a vector field.");
+                            throw new TypeError("Chalkboard.real.define: Functions in array 'rule' must have one variable to define a parametric curve or four variables to define a vector field.");
                         }
                     }
                 } else {
@@ -172,7 +162,7 @@ namespace Chalkboard {
                     } else if (f.length === 3) {
                         type = "scalar4d";
                     } else {
-                        throw new Error("The function must have one, two, or three variables to define a scalar function.");
+                        throw new TypeError("Chalkboard.real.define: Function 'rule' must have one, two, or three variables to define a scalar function.");
                     }
                 }
             }
@@ -209,7 +199,7 @@ namespace Chalkboard {
             } else if (form === "vert") {
                 return 2 * a * b * (2 * a * b) - 4 * a * c;
             } else {
-                throw new TypeError('Parameter "form" must be "stan" or "vert".');
+                throw new TypeError("Chalkboard.real.discriminant: String 'form' must be 'stan' or 'vert'.");
             }
         };
 
@@ -220,12 +210,8 @@ namespace Chalkboard {
          * @returns {ChalkboardFunction}
          */
         export const div = (func1: ChalkboardFunction, func2: ChalkboardFunction): ChalkboardFunction => {
-            if (func1.field !== "real" || func2.field !== "real") {
-                throw new TypeError('Chalkboard.real.div: Properties "field" of "func1" and "func2" must be "real".');
-            }
-            if (func1.type !== func2.type) {
-                throw new TypeError('Chalkboard.real.div: Properties "type" of "func1" and "func2" must be the same.');
-            }
+            if (func1.field !== "real" || func2.field !== "real") throw new TypeError("Chalkboard.real.div: Properties 'field' of 'func1' and 'func2' must be 'real'.");
+            if (func1.type !== func2.type) throw new TypeError("Chalkboard.real.div: Properties 'type' of 'func1' and 'func2' must be the same.");
             if (func1.type.startsWith("scalar")) {
                 const f1 = func1.rule as ((...x: number[]) => number);
                 const f2 = func2.rule as ((...x: number[]) => number);
@@ -256,7 +242,7 @@ namespace Chalkboard {
                 }
                 return Chalkboard.real.define(g, func1.type);
             }
-            throw new TypeError('Chalkboard.real.div: Properties "type" of "func1" and "func2" are not supported.');
+            throw new TypeError("Chalkboard.real.div: Properties 'type' of 'func1' and 'func2' must be 'scalar2d', 'scalar3d', 'scalar4d', 'vector2d', 'vector3d', 'vector4d', 'curve2d', 'curve3d', 'curve4d', or 'surface3d'.");
         };
 
         /**
@@ -349,12 +335,8 @@ namespace Chalkboard {
          * @returns {ChalkboardFunction}
          */
         export const mul = (func1: ChalkboardFunction, func2: ChalkboardFunction): ChalkboardFunction => {
-            if (func1.field !== "real" || func2.field !== "real") {
-                throw new TypeError('Chalkboard.real.mul: Properties "field" of "func1" and "func2" must be "real".');
-            }
-            if (func1.type !== func2.type) {
-                throw new TypeError('Chalkboard.real.mul: Properties "type" of "func1" and "func2" must be the same.');
-            }
+            if (func1.field !== "real" || func2.field !== "real") throw new TypeError("Chalkboard.real.mul: Properties 'field' of 'func1' and 'func2' must be 'real'.");
+            if (func1.type !== func2.type) throw new TypeError("Chalkboard.real.mul: Properties 'type' of 'func1' and 'func2' must be the same.");
             if (func1.type.startsWith("scalar")) {
                 const f1 = func1.rule as ((...x: number[]) => number);
                 const f2 = func2.rule as ((...x: number[]) => number);
@@ -385,7 +367,7 @@ namespace Chalkboard {
                 }
                 return Chalkboard.real.define(g, func1.type);
             }
-            throw new TypeError('Chalkboard.real.mul: Properties "type" of "func1" and "func2" are not supported.');
+            throw new TypeError("Chalkboard.real.mul: Properties 'type' of 'func1' and 'func2' must be 'scalar2d', 'scalar3d', 'scalar4d', 'vector2d', 'vector3d', 'vector4d', 'curve2d', 'curve3d', 'curve4d', or 'surface3d'.");
         };
 
         /**
@@ -394,7 +376,34 @@ namespace Chalkboard {
          * @returns {ChalkboardFunction}
          */
         export const negate = (func: ChalkboardFunction): ChalkboardFunction => {
-            return Chalkboard.real.scl(func, -1);
+            if (func.field !== "real") throw new TypeError("Chalkboard.real.negate: Property 'field' of 'func' must be 'real'.");
+            if (func.type.startsWith("scalar")) {
+                const f = func.rule as ((...x: number[]) => number);
+                const g = (...x: number[]) => -f(...x);
+                return Chalkboard.real.define(g, func.type);
+            } else if (func.type.startsWith("vector")) {
+                const f = func.rule as ((...x: number[]) => number)[];
+                const g = [];
+                for (let i = 0; i < f.length; i++) {
+                    g.push((...x: number[]) => -f[i](...x));
+                }
+                return Chalkboard.real.define(g, func.type);
+            } else if (func.type.startsWith("curve")) {
+                const f = func.rule as ((t: number) => number)[];
+                const g = [];
+                for (let i = 0; i < f.length; i++) {
+                    g.push((t: number) => -f[i](t));
+                }
+                return Chalkboard.real.define(g, func.type);
+            } else if (func.type.startsWith("surface")) {
+                const f = func.rule as ((s: number, t: number) => number)[];
+                const g = [];
+                for (let i = 0; i < f.length; i++) {
+                    g.push((s: number, t: number) => -f[i](s, t));
+                }
+                return Chalkboard.real.define(g, func.type);
+            }
+            throw new TypeError("Chalkboard.real.negate: Property 'type' of 'func' must be 'scalar2d', 'scalar3d', 'scalar4d', 'vector2d', 'vector3d', 'vector4d', 'curve2d', 'curve3d', 'curve4d', or 'surface3d'.");
         };
 
         /**
@@ -462,9 +471,7 @@ namespace Chalkboard {
                 }
             } else {
                 const func = base;
-                if (func.field !== "real") {
-                    throw new TypeError('Chalkboard.real.pow: Property "field" of "func" must be "real".');
-                }
+                if (func.field !== "real") throw new TypeError("Chalkboard.real.pow: Property 'field' of 'func' must be 'real'.");
                 if (func.type.startsWith("scalar")) {
                     const f = func.rule as ((...x: number[]) => number);
                     const g = (...x: number[]) => f(...x) ** num;
@@ -491,7 +498,7 @@ namespace Chalkboard {
                     }
                     return Chalkboard.real.define(g, func.type);
                 }
-                throw new TypeError('Chalkboard.real.pow: Property "type" of "func" is not supported.');
+                throw new TypeError("Chalkboard.real.pow: Property 'type' of 'func' must be 'scalar2d', 'scalar3d', 'scalar4d', 'vector2d', 'vector3d', 'vector4d', 'curve2d', 'curve3d', 'curve4d', or 'surface3d'.");
             }
         };
 
@@ -530,7 +537,7 @@ namespace Chalkboard {
             } else if (form === "vert") {
                 return Chalkboard.real.define((x: number) => a * (x - b) * (x - b) + c);
             } else {
-                throw new TypeError('Parameter "form" must be "stan" or "vert".');
+                throw new TypeError("Chalkboard.real.quadratic: String 'form' must be 'stan' or 'vert'.");
             }
         };
 
@@ -548,7 +555,7 @@ namespace Chalkboard {
             } else if (form === "vert") {
                 return [b + Chalkboard.real.sqrt(-c / a), b - Chalkboard.real.sqrt(-c / a)];
             } else {
-                throw new TypeError('Parameter "form" must be "stan" or "vert".');
+                throw new TypeError("Chalkboard.real.quadraticFormula: String 'form' must be 'stan' or 'vert'.");
             }
         };
 
@@ -584,9 +591,7 @@ namespace Chalkboard {
          * @returns {ChalkboardFunction}
          */
         export const reciprocate = (func: ChalkboardFunction): ChalkboardFunction => {
-            if (func.field !== "real") {
-                throw new TypeError('Chalkboard.real.reciprocate: Property "field" of "func" must be "real".');
-            }
+            if (func.field !== "real") throw new TypeError("Chalkboard.real.reciprocate: Property 'field' of 'func' must be 'real'.");
             if (func.type.startsWith("scalar")) {
                 const f = func.rule as ((...x: number[]) => number);
                 const g = (...x: number[]) => 1 / f(...x);
@@ -613,7 +618,7 @@ namespace Chalkboard {
                 }
                 return Chalkboard.real.define(g, func.type);
             }
-            throw new TypeError('Chalkboard.real.reciprocate: Property "type" of "func" is not supported.');
+            throw new TypeError("Chalkboard.real.reciprocate: Property 'type' of 'func' must be 'scalar2d', 'scalar3d', 'scalar4d', 'vector2d', 'vector3d', 'vector4d', 'curve2d', 'curve3d', 'curve4d', or 'surface3d'.");
         };
 
         /**
@@ -649,9 +654,7 @@ namespace Chalkboard {
          * @returns {ChalkboardFunction}
          */
         export const scl = (func: ChalkboardFunction, num: number): ChalkboardFunction => {
-            if (func.field !== "real") {
-                throw new TypeError('Chalkboard.real.scl: Property "field" of "func" must be "real".');
-            }
+            if (func.field !== "real") throw new TypeError("Chalkboard.real.scl: Property 'field' of 'func' must be 'real'.");
             if (func.type.startsWith("scalar")) {
                 const f = func.rule as ((...x: number[]) => number);
                 const g = (...x: number[]) => f(...x) * num;
@@ -678,7 +681,7 @@ namespace Chalkboard {
                 }
                 return Chalkboard.real.define(g, func.type);
             }
-            throw new TypeError('Chalkboard.real.scl: Property "type" of "func" is not supported.');
+            throw new TypeError("Chalkboard.real.scl: Property 'type' of 'func' must be 'scalar2d', 'scalar3d', 'scalar4d', 'vector2d', 'vector3d', 'vector4d', 'curve2d', 'curve3d', 'curve4d', or 'surface3d'.");
         };
 
         /**
@@ -713,12 +716,8 @@ namespace Chalkboard {
          * @returns {ChalkboardFunction}
          */
         export const sub = (func1: ChalkboardFunction, func2: ChalkboardFunction): ChalkboardFunction => {
-            if (func1.field !== "real" || func2.field !== "real") {
-                throw new TypeError('Chalkboard.real.sub: Properties "field" of "func1" and "func2" must be "real".');
-            }
-            if (func1.type !== func2.type) {
-                throw new TypeError('Chalkboard.real.sub: Properties "type" of "func1" and "func2" must be the same.');
-            }
+            if (func1.field !== "real" || func2.field !== "real") throw new TypeError("Chalkboard.real.sub: Properties 'field' of 'func1' and 'func2' must be 'real'.");
+            if (func1.type !== func2.type) throw new TypeError("Chalkboard.real.sub: Properties 'type' of 'func1' and 'func2' must be the same.");
             if (func1.type.startsWith("scalar")) {
                 const f1 = func1.rule as ((...x: number[]) => number);
                 const f2 = func2.rule as ((...x: number[]) => number);
@@ -749,7 +748,7 @@ namespace Chalkboard {
                 }
                 return Chalkboard.real.define(g, func1.type);
             }
-            throw new TypeError('Chalkboard.real.sub: Properties "type" of "func1" and "func2" are not supported.');
+            throw new TypeError("Chalkboard.real.sub: Properties 'type' of 'func1' and 'func2' must be 'scalar2d', 'scalar3d', 'scalar4d', 'vector2d', 'vector3d', 'vector4d', 'curve2d', 'curve3d', 'curve4d', or 'surface3d'.");
         };
 
         /**
@@ -774,68 +773,65 @@ namespace Chalkboard {
          * @returns {ChalkboardFunction}
          */
         export const translate = (func: ChalkboardFunction, h: number = 0, v: number = 0): ChalkboardFunction => {
-            if (func.field !== "real") {
-                throw new TypeError('Chalkboard.real.translate: Property "field" of "func" must be "real".');
-            }
+            if (func.field !== "real") throw new TypeError("Chalkboard.real.translate: Property 'field' of 'func' must be 'real'.");
             if (func.type === "scalar2d") {
                 const f = func.rule as (x: number) => number;
                 const g = (x: number) => f(x - h) + v;
                 return Chalkboard.real.define(g, func.type);
             }
-            throw new TypeError('Chalkboard.real.translate: Property "type" of "func" is not supported.');
+            throw new TypeError("Chalkboard.real.translate: Property 'type' of 'func' must be 'scalar2d'.");
         };
 
         /**
          * Calculates the value of a function at a value.
          * @param {ChalkboardFunction} func - The function
-         * @param {number} x - The value
+         * @param {number} val - The value
          * @returns {number | ChalkboardVector}
          */
-        export const val = (func: ChalkboardFunction, x: number | ChalkboardVector): number | ChalkboardVector => {
-            if (func.field !== "real") {
-                throw new TypeError('Chalkboard.real.val: Property "field" of "func" must be "real".');
-            }
+        export const val = (func: ChalkboardFunction, val: number | ChalkboardVector): number | ChalkboardVector => {
+            if (func.field !== "real") throw new TypeError("Chalkboard.real.val: Property 'field' of 'func' must be 'real'.");
             if (func.type === "scalar2d") {
                 const f = func.rule as (x: number) => number;
-                return f(x as number);
+                const x = val as number;
+                return f(x);
             } else if (func.type === "scalar3d") {
                 const f = func.rule as (x: number, y: number) => number;
-                const v = x as ChalkboardVector as { x: number, y: number };
+                const v = val as ChalkboardVector as { x: number, y: number };
                 return f(v.x, v.y);
             } else if (func.type === "scalar4d") {
                 const f = func.rule as (x: number, y: number, z: number) => number;
-                const v = x as ChalkboardVector as { x: number, y: number, z: number };
+                const v = val as ChalkboardVector as { x: number, y: number, z: number };
                 return f(v.x, v.y, v.z);
             } else if (func.type === "vector2d") {
                 const f = func.rule as [(x: number, y: number) => number, (x: number, y: number) => number];
-                const v = x as ChalkboardVector as { x: number, y: number };
+                const v = val as ChalkboardVector as { x: number, y: number };
                 return Chalkboard.vect.init(f[0](v.x, v.y), f[1](v.x, v.y));
             } else if (func.type === "vector3d") {
                 const f = func.rule as [(x: number, y: number, z: number) => number, (x: number, y: number, z: number) => number, (x: number, y: number, z: number) => number];
-                const v = x as ChalkboardVector as { x: number, y: number, z: number };
+                const v = val as ChalkboardVector as { x: number, y: number, z: number };
                 return Chalkboard.vect.init(f[0](v.x, v.y, v.z), f[1](v.x, v.y, v.z), f[2](v.x, v.y, v.z));
             } else if (func.type === "vector4d") {
                 const f = func.rule as [(x: number, y: number, z: number, w: number) => number, (x: number, y: number, z: number, w: number) => number, (x: number, y: number, z: number, w: number) => number, (x: number, y: number, z: number, w: number) => number];
-                const v = x as ChalkboardVector as { x: number, y: number, z: number, w: number };
+                const v = val as ChalkboardVector as { x: number, y: number, z: number, w: number };
                 return Chalkboard.vect.init(f[0](v.x, v.y, v.z, v.w), f[1](v.x, v.y, v.z, v.w), f[2](v.x, v.y, v.z, v.w), f[3](v.x, v.y, v.z, v.w));
             } else if (func.type === "curve2d") {
                 const f = func.rule as [(t: number) => number, (t: number) => number];
-                const t = x as number;
+                const t = val as number;
                 return Chalkboard.vect.init(f[0](t), f[1](t));
             } else if (func.type === "curve3d") {
                 const f = func.rule as [(t: number) => number, (t: number) => number, (t: number) => number];
-                const t = x as number;
+                const t = val as number;
                 return Chalkboard.vect.init(f[0](t), f[1](t), f[2](t));
             } else if (func.type === "curve4d") {
                 const f = func.rule as [(t: number) => number, (t: number) => number, (t: number) => number, (t: number) => number];
-                const t = x as number;
+                const t = val as number;
                 return Chalkboard.vect.init(f[0](t), f[1](t), f[2](t), f[3](t));
             } else if (func.type === "surface3d") {
                 const f = func.rule as [(s: number, t: number) => number, (s: number, t: number) => number, (s: number, t: number) => number];
-                const v = x as ChalkboardVector as { x: number, y: number };
+                const v = val as ChalkboardVector as { x: number, y: number };
                 return Chalkboard.vect.init(f[0](v.x, v.y), f[1](v.x, v.y), f[2](v.x, v.y));
             }
-            throw new TypeError('Chalkboard.real.val: Property "type" of "func" is not supported.');
+            throw new TypeError("Chalkboard.real.val: Property 'type' of 'func' must be 'scalar2d', 'scalar3d', 'scalar4d', 'vector2d', 'vector3d', 'vector4d', 'curve2d', 'curve3d', 'curve4d', or 'surface3d'");
         };
 
         /**
@@ -865,7 +861,7 @@ namespace Chalkboard {
             } else if (type === "surface3d") {
                 return Chalkboard.real.define([() => 0, () => 0, () => 0], type);
             }
-            throw new TypeError('Chalkboard.real.zero: Inputted "type" is not supported.');
+            throw new TypeError("Chalkboard.real.zero: String 'type' must be 'scalar2d', 'scalar3d', 'scalar4d', 'vector2d', 'vector3d', 'vector4d', 'curve2d', 'curve3d', 'curve4d', or 'surface3d'.");
         };
     }
 }

--- a/src/Chalkboard-real.ts
+++ b/src/Chalkboard-real.ts
@@ -15,18 +15,36 @@ namespace Chalkboard {
          * @returns {ChalkboardFunction}
          */
         export const absolute = (func: ChalkboardFunction): ChalkboardFunction => {
-            if (func.type === "expl" || func.type === "inve" || func.type === "pola" || func.type === "mult") {
-                return Chalkboard.real.define(`Math.abs(${func.definition})`, func.type);
-            } else if (func.type === "curv" && Array.isArray(func.definition)) {
-                if (func.definition.length === 2) {
-                    return Chalkboard.real.define([`Math.abs(${func.definition[0]})`, `Math.abs(${func.definition[1]})`], "curv");
-                } else if (func.definition.length === 3) {
-                    return Chalkboard.real.define([`Math.abs(${func.definition[0]})`, `Math.abs(${func.definition[1]})`, `Math.abs(${func.definition[2]})`], "curv");
-                }
-            } else if (func.type === "surf" && Array.isArray(func.definition)) {
-                return Chalkboard.real.define([`Math.abs(${func.definition[0]})`, `Math.abs(${func.definition[1]})`, `Math.abs(${func.definition[2]})`], "surf");
+            if (func.field !== "real") {
+                throw new TypeError('Chalkboard.real.absolute: Property "field" of "func" must be "real".');
             }
-            throw new TypeError('Property "type" of "func" must be either "expl", "inve", "pola", "curv", "surf", or "mult".');
+            if (func.type.startsWith("scalar")) {
+                const f = func.rule as ((...x: number[]) => number);
+                const g = (...x: number[]) => Math.abs(f(...x));
+                return Chalkboard.real.define(g, func.type);
+            } else if (func.type.startsWith("vector")) {
+                const f = func.rule as ((...x: number[]) => number)[];
+                const g = [];
+                for (let i = 0; i < f.length; i++) {
+                    g.push((...x: number[]) => Math.abs(f[i](...x)));
+                }
+                return Chalkboard.real.define(g, func.type);
+            } else if (func.type.startsWith("curve")) {
+                const f = func.rule as ((t: number) => number)[];
+                const g = [];
+                for (let i = 0; i < f.length; i++) {
+                    g.push((t: number) => Math.abs(f[i](t)));
+                }
+                return Chalkboard.real.define(g, func.type);
+            } else if (func.type.startsWith("surface")) {
+                const f = func.rule as ((s: number, t: number) => number)[];
+                const g = [];
+                for (let i = 0; i < f.length; i++) {
+                    g.push((s: number, t: number) => Math.abs(f[i](s, t)));
+                }
+                return Chalkboard.real.define(g, func.type);
+            }
+            throw new TypeError('Chalkboard.real.absolute: Property "type" of "func" is not supported.');
         };
 
         /**
@@ -36,18 +54,43 @@ namespace Chalkboard {
          * @returns {ChalkboardFunction}
          */
         export const add = (func1: ChalkboardFunction, func2: ChalkboardFunction): ChalkboardFunction => {
-            if ((func1.type === "expl" && func2.type === "expl") || (func1.type === "inve" && func2.type === "inve") || (func1.type === "pola" && func2.type === "pola") || (func1.type === "mult" && func2.type === "mult")) {
-                return Chalkboard.real.define(`(${func1.definition}) + (${func2.definition})`, func1.type);
-            } else if (func1.type === "curv" && func2.type === "curv" && Array.isArray(func1.definition) && Array.isArray(func2.definition)) {
-                if (func1.definition.length === 2 && func2.definition.length === 2) {
-                    return Chalkboard.real.define([`(${func1.definition[0]}) + (${func2.definition[0]})`, `(${func1.definition[1]}) + (${func2.definition[1]})`], "curv");
-                } else if (func1.definition.length === 3 && func2.definition.length === 3) {
-                    return Chalkboard.real.define([`(${func1.definition[0]}) + (${func2.definition[0]})`, `(${func1.definition[1]}) + (${func2.definition[1]})`, `(${func1.definition[2]}) + (${func2.definition[2]})`], "curv");
-                }
-            } else if (func1.type === "surf" && func2.type === "surf" && Array.isArray(func1.definition) && Array.isArray(func2.definition)) {
-                return Chalkboard.real.define([`(${func1.definition[0]}) + (${func2.definition[0]})`, `(${func1.definition[1]}) + (${func2.definition[1]})`, `(${func1.definition[2]}) + (${func2.definition[2]})`], "surf");
+            if (func1.field !== "real" || func2.field !== "real") {
+                throw new TypeError('Chalkboard.real.add: Properties "field" of "func1" and "func2" must be "real".');
             }
-            throw new TypeError('Property "type" of "func1" and "func2" must be either "expl", "inve", "pola", "curv", "surf", or "mult".');
+            if (func1.type !== func2.type) {
+                throw new TypeError('Chalkboard.real.add: Properties "type" of "func1" and "func2" must be the same.');
+            }
+            if (func1.type.startsWith("scalar")) {
+                const f1 = func1.rule as ((...x: number[]) => number);
+                const f2 = func2.rule as ((...x: number[]) => number);
+                const g = (...x: number[]) => f1(...x) + f2(...x);
+                return Chalkboard.real.define(g, func1.type);
+            } else if (func1.type.startsWith("vector")) {
+                const f1 = func1.rule as ((...x: number[]) => number)[];
+                const f2 = func2.rule as ((...x: number[]) => number)[];
+                const g = [];
+                for (let i = 0; i < f1.length; i++) {
+                    g.push((...x: number[]) => f1[i](...x) + f2[i](...x));
+                }
+                return Chalkboard.real.define(g, func1.type);
+            } else if (func1.type.startsWith("curve")) {
+                const f1 = func1.rule as ((t: number) => number)[];
+                const f2 = func2.rule as ((t: number) => number)[];
+                const g = [];
+                for (let i = 0; i < f1.length; i++) {
+                    g.push((t: number) => f1[i](t) + f2[i](t));
+                }
+                return Chalkboard.real.define(g, func1.type);
+            } else if (func1.type.startsWith("surface")) {
+                const f1 = func1.rule as ((s: number, t: number) => number)[];
+                const f2 = func2.rule as ((s: number, t: number) => number)[];
+                const g = [];
+                for (let i = 0; i < f1.length; i++) {
+                    g.push((s: number, t: number) => f1[i](s, t) + f2[i](s, t));
+                }
+                return Chalkboard.real.define(g, func1.type);
+            }
+            throw new TypeError('Chalkboard.real.add: Properties "type" of "func1" and "func2" are not supported.');
         };
 
         /**
@@ -57,22 +100,27 @@ namespace Chalkboard {
          * @returns {ChalkboardFunction}
          */
         export const compose = (func1: ChalkboardFunction, func2: ChalkboardFunction): ChalkboardFunction => {
-            if (func1.type === "expl" && func2.type === "expl") {
-                return Chalkboard.real.define(`(${func1.definition.toString().replace(/x/g, `(${func2.definition})`)})`, "expl");
-            } else if (func1.type === "inve" && func2.type === "inve") {
-                return Chalkboard.real.define(`(${func1.definition.toString().replace(/y/g, `(${func2.definition})`)})`, "inve");
-            } else if (func1.type === "pola" && func2.type === "pola") {
-                return Chalkboard.real.define(`(${func1.definition.toString().replace(/O/g, `(${func2.definition})`)})`, "pola");
-            } else if (func1.type === "curv" && func2.type === "curv" && Array.isArray(func1.definition) && Array.isArray(func2.definition)) {
-                if (func1.definition.length === 2 && func2.definition.length === 2) {
-                    return Chalkboard.real.define([`(${func1.definition[0].toString().replace(/x/g, `(${func2.definition[0]})`)})`, `(${func1.definition[1].toString().replace(/y/g, `(${func2.definition[1]})`)})`], "curv");
-                } else if (func1.definition.length === 3 && func2.definition.length === 3) {
-                    return Chalkboard.real.define([`(${func1.definition[0].toString().replace(/x/g, `(${func2.definition[0]})`)})`, `(${func1.definition[1].toString().replace(/y/g, `(${func2.definition[1]})`)})`, `(${func1.definition[2].toString().replace(/z/g, `(${func2.definition[2]})`)})`], "curv");
-                }
-            } else if (func1.type === "surf" && func2.type === "surf" && Array.isArray(func1.definition) && Array.isArray(func2.definition)) {
-                return Chalkboard.real.define([`(${func1.definition[0].toString().replace(/x/g, `(${func2.definition[0]})`)})`, `(${func1.definition[1].toString().replace(/y/g, `(${func2.definition[1]})`)})`, `(${func1.definition[2].toString().replace(/z/g, `(${func2.definition[2]})`)})`], "surf");
+            if (func1.field !== "real" || func2.field !== "real") {
+                throw new TypeError('Chalkboard.real.compose: Properties "field" of "func1" and "func2" must be "real".');
             }
-            throw new TypeError('Property "type" of "func1" and "func2" must be either "expl", "inve", "pola", "curv", or "surf".');
+            if (func1.type !== func2.type) {
+                throw new TypeError('Chalkboard.real.compose: Properties "type" of "func1" and "func2" must be the same.');
+            }
+            if (func1.type.startsWith("scalar")) {
+                const f1 = func1.rule as ((...x: number[]) => number);
+                const f2 = func2.rule as ((...x: number[]) => number);
+                const g = (...x: number[]) => f1(f2(...x));
+                return Chalkboard.real.define(g, func1.type);
+            } else if (func1.type.startsWith("vector")) {
+                const f1 = func1.rule as ((...x: number[]) => number)[];
+                const f2 = func2.rule as ((...x: number[]) => number)[];
+                const g = [];
+                for (let i = 0; i < f1.length; i++) {
+                    g.push((...x: number[]) => f1[i](f2[i](...x)));
+                }
+                return Chalkboard.real.define(g, func1.type);
+            }
+            throw new TypeError('Chalkboard.real.compose: Properties "type" of "func1" and "func2" are not supported.');
         };
 
         /**
@@ -172,18 +220,43 @@ namespace Chalkboard {
          * @returns {ChalkboardFunction}
          */
         export const div = (func1: ChalkboardFunction, func2: ChalkboardFunction): ChalkboardFunction => {
-            if ((func1.type === "expl" && func2.type === "expl") || (func1.type === "inve" && func2.type === "inve") || (func1.type === "pola" && func2.type === "pola") || (func1.type === "mult" && func2.type === "mult")) {
-                return Chalkboard.real.define(`(${func1.definition}) / (${func2.definition})`, func1.type);
-            } else if (func1.type === "curv" && func2.type === "curv" && Array.isArray(func1.definition) && Array.isArray(func2.definition)) {
-                if (func1.definition.length === 2) {
-                    return Chalkboard.real.define([`(${func1.definition[0]}) / (${func2.definition[0]})`, `(${func1.definition[1]}) / (${func2.definition[1]})`], "curv");
-                } else if (func1.definition.length === 3) {
-                    return Chalkboard.real.define([`(${func1.definition[0]}) / (${func2.definition[0]})`, `(${func1.definition[1]}) / (${func2.definition[1]})`, `(${func1.definition[2]}) / (${func2.definition[2]})`], "curv");
-                }
-            } else if (func1.type === "surf" && func2.type === "surf" && Array.isArray(func1.definition) && Array.isArray(func2.definition)) {
-                return Chalkboard.real.define([`(${func1.definition[0]}) / (${func2.definition[0]})`, `(${func1.definition[1]}) / (${func2.definition[1]})`, `(${func1.definition[2]}) / (${func2.definition[2]})`], "surf");
+            if (func1.field !== "real" || func2.field !== "real") {
+                throw new TypeError('Chalkboard.real.div: Properties "field" of "func1" and "func2" must be "real".');
             }
-            throw new TypeError('Property "type" of "func1" and "func2" must be either "expl", "inve", "pola", "curv", "surf", or "mult".');
+            if (func1.type !== func2.type) {
+                throw new TypeError('Chalkboard.real.div: Properties "type" of "func1" and "func2" must be the same.');
+            }
+            if (func1.type.startsWith("scalar")) {
+                const f1 = func1.rule as ((...x: number[]) => number);
+                const f2 = func2.rule as ((...x: number[]) => number);
+                const g = (...x: number[]) => f1(...x) / f2(...x);
+                return Chalkboard.real.define(g, func1.type);
+            } else if (func1.type.startsWith("vector")) {
+                const f1 = func1.rule as ((...x: number[]) => number)[];
+                const f2 = func2.rule as ((...x: number[]) => number)[];
+                const g = [];
+                for (let i = 0; i < f1.length; i++) {
+                    g.push((...x: number[]) => f1[i](...x) / f2[i](...x));
+                }
+                return Chalkboard.real.define(g, func1.type);
+            } else if (func1.type.startsWith("curve")) {
+                const f1 = func1.rule as ((t: number) => number)[];
+                const f2 = func2.rule as ((t: number) => number)[];
+                const g = [];
+                for (let i = 0; i < f1.length; i++) {
+                    g.push((t: number) => f1[i](t) / f2[i](t));
+                }
+                return Chalkboard.real.define(g, func1.type);
+            } else if (func1.type.startsWith("surface")) {
+                const f1 = func1.rule as ((s: number, t: number) => number)[];
+                const f2 = func2.rule as ((s: number, t: number) => number)[];
+                const g = [];
+                for (let i = 0; i < f1.length; i++) {
+                    g.push((s: number, t: number) => f1[i](s, t) / f2[i](s, t));
+                }
+                return Chalkboard.real.define(g, func1.type);
+            }
+            throw new TypeError('Chalkboard.real.div: Properties "type" of "func1" and "func2" are not supported.');
         };
 
         /**
@@ -220,7 +293,7 @@ namespace Chalkboard {
          * @returns {ChalkboardFunction}
          */
         export const linear = (x1: number, y1: number, x2: number, y2: number): ChalkboardFunction => {
-            return Chalkboard.real.define(Chalkboard.real.slope(x1, y1, x2, y2).toString() + " * (x - " + x2.toString() + ") + " + y2.toString());
+            return Chalkboard.real.define((x: number) => Chalkboard.real.slope(x1, y1, x2, y2) * (x - x2) + y2);
         };
 
         /**
@@ -247,7 +320,7 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const ln = (num: number): number => {
-            return Chalkboard.calc.fxdx(Chalkboard.real.define("1 / x"), 1, num) as number;
+            return Chalkboard.calc.fxdx(Chalkboard.real.define((x: number) => 1 / x), 1, num) as number;
         };
 
         /**
@@ -276,18 +349,43 @@ namespace Chalkboard {
          * @returns {ChalkboardFunction}
          */
         export const mul = (func1: ChalkboardFunction, func2: ChalkboardFunction): ChalkboardFunction => {
-            if ((func1.type === "expl" && func2.type === "expl") || (func1.type === "inve" && func2.type === "inve") || (func1.type === "pola" && func2.type === "pola") || (func1.type === "mult" && func2.type === "mult")) {
-                return Chalkboard.real.define(`(${func1.definition}) * (${func2.definition})`, func1.type);
-            } else if (func1.type === "curv" && func2.type === "curv" && Array.isArray(func1.definition) && Array.isArray(func2.definition)) {
-                if (func1.definition.length === 2) {
-                    return Chalkboard.real.define([`(${func1.definition[0]}) * (${func2.definition[0]})`, `(${func1.definition[1]}) * (${func2.definition[1]})`], "curv");
-                } else if (func1.definition.length === 3) {
-                    return Chalkboard.real.define([`(${func1.definition[0]}) * (${func2.definition[0]})`, `(${func1.definition[1]}) * (${func2.definition[1]})`, `(${func1.definition[2]}) * (${func2.definition[2]})`], "curv");
-                }
-            } else if (func1.type === "surf" && func2.type === "surf" && Array.isArray(func1.definition) && Array.isArray(func2.definition)) {
-                return Chalkboard.real.define([`(${func1.definition[0]}) * (${func2.definition[0]})`, `(${func1.definition[1]}) * (${func2.definition[1]})`, `(${func1.definition[2]}) * (${func2.definition[2]})`], "surf");
+            if (func1.field !== "real" || func2.field !== "real") {
+                throw new TypeError('Chalkboard.real.mul: Properties "field" of "func1" and "func2" must be "real".');
             }
-            throw new TypeError('Property "type" of "func1" and "func2" must be either "expl", "inve", "pola", "curv", "surf", or "mult".');
+            if (func1.type !== func2.type) {
+                throw new TypeError('Chalkboard.real.mul: Properties "type" of "func1" and "func2" must be the same.');
+            }
+            if (func1.type.startsWith("scalar")) {
+                const f1 = func1.rule as ((...x: number[]) => number);
+                const f2 = func2.rule as ((...x: number[]) => number);
+                const g = (...x: number[]) => f1(...x) * f2(...x);
+                return Chalkboard.real.define(g, func1.type);
+            } else if (func1.type.startsWith("vector")) {
+                const f1 = func1.rule as ((...x: number[]) => number)[];
+                const f2 = func2.rule as ((...x: number[]) => number)[];
+                const g = [];
+                for (let i = 0; i < f1.length; i++) {
+                    g.push((...x: number[]) => f1[i](...x) * f2[i](...x));
+                }
+                return Chalkboard.real.define(g, func1.type);
+            } else if (func1.type.startsWith("curve")) {
+                const f1 = func1.rule as ((t: number) => number)[];
+                const f2 = func2.rule as ((t: number) => number)[];
+                const g = [];
+                for (let i = 0; i < f1.length; i++) {
+                    g.push((t: number) => f1[i](t) * f2[i](t));
+                }
+                return Chalkboard.real.define(g, func1.type);
+            } else if (func1.type.startsWith("surface")) {
+                const f1 = func1.rule as ((s: number, t: number) => number)[];
+                const f2 = func2.rule as ((s: number, t: number) => number)[];
+                const g = [];
+                for (let i = 0; i < f1.length; i++) {
+                    g.push((s: number, t: number) => f1[i](s, t) * f2[i](s, t));
+                }
+                return Chalkboard.real.define(g, func1.type);
+            }
+            throw new TypeError('Chalkboard.real.mul: Properties "type" of "func1" and "func2" are not supported.');
         };
 
         /**
@@ -333,31 +431,20 @@ namespace Chalkboard {
             if (coeffs.length === 1 && Array.isArray(coeffs[0])) {
                 arr = coeffs[0];
             } else {
-                arr = coeffs as number[];
+                arr = coeffs;
             }
-            let result = "";
-            for (let i = 0; i < arr.length; i++) {
-                const coeff = arr[i];
-                const exponent = arr.length - i - 1;
-                if (coeff === 0 && exponent !== 0) continue;
-                if (result !== "") {
-                    result += coeff >= 0 ? " + " : " - ";
-                } else if (coeff < 0) {
-                    result += "-";
-                }
-                const abscoeff = Math.abs(coeff);
-                let term = "";
-                if (exponent === 0) {
-                    term = abscoeff.toString();
-                } else if (exponent === 1) {
-                    term = (abscoeff === 1 ? "" : abscoeff + " * ") + "x";
-                } else {
-                    term = (abscoeff === 1 ? "" : abscoeff + " * ") + "x ** " + exponent;
-                }
-                result += "(" + term + ")";
+            while (arr.length > 1 && arr[0] === 0) {
+                arr.shift();
             }
-            if (result === "") result = "0";
-            return Chalkboard.real.define(result, "expl");
+            const f = (x: number): number => {
+                if (arr.length === 0) return 0;
+                let result = arr[0];
+                for (let i = 1; i < arr.length; i++) {
+                    result = result * x + arr[i];
+                }
+                return result;
+            };
+            return Chalkboard.real.define(f);
         };
 
         /**
@@ -375,18 +462,36 @@ namespace Chalkboard {
                 }
             } else {
                 const func = base;
-                if (func.type === "expl" || func.type === "inve" || func.type === "pola" || func.type === "mult") {
-                    return Chalkboard.real.define(`(${func.definition}) ** ${num}`, func.type);
-                } else if (func.type === "curv" && Array.isArray(func.definition)) {
-                    if (func.definition.length === 2) {
-                        return Chalkboard.real.define([`(${func.definition[0]}) ** ${num}`, `(${func.definition[1]}) ** ${num}`], "curv");
-                    } else if (func.definition.length === 3) {
-                        return Chalkboard.real.define([`(${func.definition[0]}) ** ${num}`, `(${func.definition[1]}) ** ${num}`, `(${func.definition[2]}) ** ${num}`], "curv");
-                    }
-                } else if (func.type === "surf" && Array.isArray(func.definition)) {
-                    return Chalkboard.real.define([`(${func.definition[0]}) ** ${num}`, `(${func.definition[1]}) ** ${num}`, `(${func.definition[2]}) ** ${num}`], "surf");
+                if (func.field !== "real") {
+                    throw new TypeError('Chalkboard.real.pow: Property "field" of "func" must be "real".');
                 }
-                throw new TypeError('Property "type" of "base" must be either "expl", "inve", "pola", "curv", "surf", or "mult".');
+                if (func.type.startsWith("scalar")) {
+                    const f = func.rule as ((...x: number[]) => number);
+                    const g = (...x: number[]) => f(...x) ** num;
+                    return Chalkboard.real.define(g, func.type);
+                } else if (func.type.startsWith("vector")) {
+                    const f = func.rule as ((...x: number[]) => number)[];
+                    const g = [];
+                    for (let i = 0; i < f.length; i++) {
+                        g.push((...x: number[]) => f[i](...x) ** num);
+                    }
+                    return Chalkboard.real.define(g, func.type);
+                } else if (func.type.startsWith("curve")) {
+                    const f = func.rule as ((t: number) => number)[];
+                    const g = [];
+                    for (let i = 0; i < f.length; i++) {
+                        g.push((t: number) => f[i](t) ** num);
+                    }
+                    return Chalkboard.real.define(g, func.type);
+                } else if (func.type.startsWith("surface")) {
+                    const f = func.rule as ((s: number, t: number) => number)[];
+                    const g = [];
+                    for (let i = 0; i < f.length; i++) {
+                        g.push((s: number, t: number) => f[i](s, t) ** num);
+                    }
+                    return Chalkboard.real.define(g, func.type);
+                }
+                throw new TypeError('Chalkboard.real.pow: Property "type" of "func" is not supported.');
             }
         };
 
@@ -421,9 +526,9 @@ namespace Chalkboard {
          */
         export const quadratic = (a: number, b: number, c: number, form: "stan" | "vert" = "stan"): ChalkboardFunction => {
             if (form === "stan") {
-                return Chalkboard.real.define(a.toString() + "* x * x + " + b.toString() + " * x +" + c.toString());
+                return Chalkboard.real.define((x: number) => a * x * x + b * x + c);
             } else if (form === "vert") {
-                return Chalkboard.real.define(a.toString() + " * ((x - " + b.toString() + ") * (x - " + b.toString() + ")) +" + c.toString());
+                return Chalkboard.real.define((x: number) => a * (x - b) * (x - b) + c);
             } else {
                 throw new TypeError('Parameter "form" must be "stan" or "vert".');
             }
@@ -479,18 +584,36 @@ namespace Chalkboard {
          * @returns {ChalkboardFunction}
          */
         export const reciprocate = (func: ChalkboardFunction): ChalkboardFunction => {
-            if (func.type === "expl" || func.type === "inve" || func.type === "pola" || func.type === "mult") {
-                return Chalkboard.real.define(`1 / (${func.definition})`, func.type);
-            } else if (func.type === "curv" && Array.isArray(func.definition)) {
-                if (func.definition.length === 2) {
-                    return Chalkboard.real.define([`1 / (${func.definition[0]})`, `1 / (${func.definition[1]})`], "curv");
-                } else if (func.definition.length === 3) {
-                    return Chalkboard.real.define([`1 / (${func.definition[0]})`, `1 / (${func.definition[1]})`, `1 / (${func.definition[2]})`], "curv");
-                }
-            } else if (func.type === "surf" && Array.isArray(func.definition)) {
-                return Chalkboard.real.define([`1 / (${func.definition[0]})`, `1 / (${func.definition[1]})`, `1 / (${func.definition[2]})`], "surf");
+            if (func.field !== "real") {
+                throw new TypeError('Chalkboard.real.reciprocate: Property "field" of "func" must be "real".');
             }
-            throw new TypeError('Property "type" of "func" must be either "expl", "inve", "pola", "curv", "surf", or "mult".');
+            if (func.type.startsWith("scalar")) {
+                const f = func.rule as ((...x: number[]) => number);
+                const g = (...x: number[]) => 1 / f(...x);
+                return Chalkboard.real.define(g, func.type);
+            } else if (func.type.startsWith("vector")) {
+                const f = func.rule as ((...x: number[]) => number)[];
+                const g = [];
+                for (let i = 0; i < f.length; i++) {
+                    g.push((...x: number[]) => 1 / f[i](...x));
+                }
+                return Chalkboard.real.define(g, func.type);
+            } else if (func.type.startsWith("curve")) {
+                const f = func.rule as ((t: number) => number)[];
+                const g = [];
+                for (let i = 0; i < f.length; i++) {
+                    g.push((t: number) => 1 / f[i](t));
+                }
+                return Chalkboard.real.define(g, func.type);
+            } else if (func.type.startsWith("surface")) {
+                const f = func.rule as ((s: number, t: number) => number)[];
+                const g = [];
+                for (let i = 0; i < f.length; i++) {
+                    g.push((s: number, t: number) => 1 / f[i](s, t));
+                }
+                return Chalkboard.real.define(g, func.type);
+            }
+            throw new TypeError('Chalkboard.real.reciprocate: Property "type" of "func" is not supported.');
         };
 
         /**
@@ -526,18 +649,36 @@ namespace Chalkboard {
          * @returns {ChalkboardFunction}
          */
         export const scl = (func: ChalkboardFunction, num: number): ChalkboardFunction => {
-            if (func.type === "expl" || func.type === "inve" || func.type === "pola" || func.type === "mult") {
-                return Chalkboard.real.define(`${num} * (${func.definition})`, func.type);
-            } else if (func.type === "curv" && Array.isArray(func.definition)) {
-                if (func.definition.length === 2) {
-                    return Chalkboard.real.define([`${num} * (${func.definition[0]})`, `${num} * (${func.definition[1]})`], "curv");
-                } else if (func.definition.length === 3) {
-                    return Chalkboard.real.define([`${num} * (${func.definition[0]})`, `${num} * (${func.definition[1]})`, `${num} * (${func.definition[2]})`], "curv");
-                }
-            } else if (func.type === "surf" && Array.isArray(func.definition)) {
-                return Chalkboard.real.define([`${num} * (${func.definition[0]})`, `${num} * (${func.definition[1]})`, `${num} * (${func.definition[2]})`], "surf");
+            if (func.field !== "real") {
+                throw new TypeError('Chalkboard.real.scl: Property "field" of "func" must be "real".');
             }
-            throw new TypeError('Property "type" of "func" must be either "expl", "inve", "pola", "curv", "surf", or "mult".');
+            if (func.type.startsWith("scalar")) {
+                const f = func.rule as ((...x: number[]) => number);
+                const g = (...x: number[]) => f(...x) * num;
+                return Chalkboard.real.define(g, func.type);
+            } else if (func.type.startsWith("vector")) {
+                const f = func.rule as ((...x: number[]) => number)[];
+                const g = [];
+                for (let i = 0; i < f.length; i++) {
+                    g.push((...x: number[]) => f[i](...x) * num);
+                }
+                return Chalkboard.real.define(g, func.type);
+            } else if (func.type.startsWith("curve")) {
+                const f = func.rule as ((t: number) => number)[];
+                const g = [];
+                for (let i = 0; i < f.length; i++) {
+                    g.push((t: number) => f[i](t) * num);
+                }
+                return Chalkboard.real.define(g, func.type);
+            } else if (func.type.startsWith("surface")) {
+                const f = func.rule as ((s: number, t: number) => number)[];
+                const g = [];
+                for (let i = 0; i < f.length; i++) {
+                    g.push((s: number, t: number) => f[i](s, t) * num);
+                }
+                return Chalkboard.real.define(g, func.type);
+            }
+            throw new TypeError('Chalkboard.real.scl: Property "type" of "func" is not supported.');
         };
 
         /**
@@ -572,18 +713,43 @@ namespace Chalkboard {
          * @returns {ChalkboardFunction}
          */
         export const sub = (func1: ChalkboardFunction, func2: ChalkboardFunction): ChalkboardFunction => {
-            if ((func1.type === "expl" && func2.type === "expl") || (func1.type === "inve" && func2.type === "inve") || (func1.type === "pola" && func2.type === "pola") || (func1.type === "mult" && func2.type === "mult")) {
-                return Chalkboard.real.define(`(${func1.definition}) - (${func2.definition})`, func1.type);
-            } else if (func1.type === "curv" && func2.type === "curv" && Array.isArray(func1.definition) && Array.isArray(func2.definition)) {
-                if (func1.definition.length === 2 && func2.definition.length === 2) {
-                    return Chalkboard.real.define([`(${func1.definition[0]}) - (${func2.definition[0]})`, `(${func1.definition[1]}) - (${func2.definition[1]})`], "curv");
-                } else if (func1.definition.length === 3 && func2.definition.length === 3) {
-                    return Chalkboard.real.define([`(${func1.definition[0]}) - (${func2.definition[0]})`, `(${func1.definition[1]}) - (${func2.definition[1]})`, `(${func1.definition[2]}) - (${func2.definition[2]})`], "curv");
-                }
-            } else if (func1.type === "surf" && func2.type === "surf" && Array.isArray(func1.definition) && Array.isArray(func2.definition)) {
-                return Chalkboard.real.define([`(${func1.definition[0]}) - (${func2.definition[0]})`, `(${func1.definition[1]}) - (${func2.definition[1]})`, `(${func1.definition[2]}) - (${func2.definition[2]})`], "surf");
+            if (func1.field !== "real" || func2.field !== "real") {
+                throw new TypeError('Chalkboard.real.sub: Properties "field" of "func1" and "func2" must be "real".');
             }
-            throw new TypeError('Property "type" of "func1" and "func2" must be either "expl", "inve", "pola", "curv", "surf", or "mult".');
+            if (func1.type !== func2.type) {
+                throw new TypeError('Chalkboard.real.sub: Properties "type" of "func1" and "func2" must be the same.');
+            }
+            if (func1.type.startsWith("scalar")) {
+                const f1 = func1.rule as ((...x: number[]) => number);
+                const f2 = func2.rule as ((...x: number[]) => number);
+                const g = (...x: number[]) => f1(...x) - f2(...x);
+                return Chalkboard.real.define(g, func1.type);
+            } else if (func1.type.startsWith("vector")) {
+                const f1 = func1.rule as ((...x: number[]) => number)[];
+                const f2 = func2.rule as ((...x: number[]) => number)[];
+                const g = [];
+                for (let i = 0; i < f1.length; i++) {
+                    g.push((...x: number[]) => f1[i](...x) - f2[i](...x));
+                }
+                return Chalkboard.real.define(g, func1.type);
+            } else if (func1.type.startsWith("curve")) {
+                const f1 = func1.rule as ((t: number) => number)[];
+                const f2 = func2.rule as ((t: number) => number)[];
+                const g = [];
+                for (let i = 0; i < f1.length; i++) {
+                    g.push((t: number) => f1[i](t) - f2[i](t));
+                }
+                return Chalkboard.real.define(g, func1.type);
+            } else if (func1.type.startsWith("surface")) {
+                const f1 = func1.rule as ((s: number, t: number) => number)[];
+                const f2 = func2.rule as ((s: number, t: number) => number)[];
+                const g = [];
+                for (let i = 0; i < f1.length; i++) {
+                    g.push((s: number, t: number) => f1[i](s, t) - f2[i](s, t));
+                }
+                return Chalkboard.real.define(g, func1.type);
+            }
+            throw new TypeError('Chalkboard.real.sub: Properties "type" of "func1" and "func2" are not supported.');
         };
 
         /**
@@ -608,76 +774,98 @@ namespace Chalkboard {
          * @returns {ChalkboardFunction}
          */
         export const translate = (func: ChalkboardFunction, h: number = 0, v: number = 0): ChalkboardFunction => {
-            if (func.type === "expl") {
-                if (h !== 0 && v !== 0) {
-                    return Chalkboard.real.define(`(${func.definition.toString().replace(/x/g, `(x - ${h})`)}) + ${v}`, "expl");
-                } else if (h !== 0) {
-                    return Chalkboard.real.define(`${func.definition.toString().replace(/x/g, `(x - ${h})`)}`, "expl");
-                } else if (v !== 0) {
-                    return Chalkboard.real.define(`(${func.definition}) + ${v}`, "expl");
-                } else {
-                    return func;
-                }
+            if (func.field !== "real") {
+                throw new TypeError('Chalkboard.real.translate: Property "field" of "func" must be "real".');
             }
-            throw new TypeError('Property "type" of "func" must be "expl".');
+            if (func.type === "scalar2d") {
+                const f = func.rule as (x: number) => number;
+                const g = (x: number) => f(x - h) + v;
+                return Chalkboard.real.define(g, func.type);
+            }
+            throw new TypeError('Chalkboard.real.translate: Property "type" of "func" is not supported.');
         };
 
         /**
          * Calculates the value of a function at a value.
          * @param {ChalkboardFunction} func - The function
-         * @param {number} val - The value
+         * @param {number} x - The value
          * @returns {number | ChalkboardVector}
          */
-        export const val = (func: ChalkboardFunction, val: number | ChalkboardVector): number | ChalkboardVector => {
-            if (func.type === "expl") {
-                const f = Chalkboard.real.parse("x => " + func.definition);
-                return f(val);
-            } else if (func.type === "inve") {
-                const f = Chalkboard.real.parse("y => " + func.definition);
-                return f(val);
-            } else if (func.type === "pola") {
-                const r = Chalkboard.real.parse("O => " + func.definition);
-                return r(val);
-            } else if (func.type === "curv") {
-                if (func.definition.length === 2) {
-                    const x = Chalkboard.real.parse("t => " + func.definition[0]),
-                        y = Chalkboard.real.parse("t => " + func.definition[1]);
-                    return Chalkboard.vect.init(x(val), y(val));
-                } else {
-                    const x = Chalkboard.real.parse("t => " + func.definition[0]),
-                        y = Chalkboard.real.parse("t => " + func.definition[1]),
-                        z = Chalkboard.real.parse("t => " + func.definition[2]);
-                    return Chalkboard.vect.init(x(val), y(val), z(val));
-                }
-            } else if (func.type === "surf") {
-                const vect = val as ChalkboardVector as { x: number, y: number, z?: number, w?: number };
-                const x = Chalkboard.real.parse("(s, t) => " + func.definition[0]),
-                    y = Chalkboard.real.parse("(s, t) => " + func.definition[1]),
-                    z = Chalkboard.real.parse("(s, t) => " + func.definition[2]);
-                return Chalkboard.vect.init(x(vect.x, vect.y), y(vect.x, vect.y), z(vect.x, vect.y));
-            } else if (func.type === "mult" && typeof val !== "number") {
-                const vect = val as ChalkboardVector as { x: number, y: number, z?: number, w?: number };
-                const f = Chalkboard.real.parse("(x, y) => " + func.definition);
-                return f(vect.x, vect.y);
-            } else {
-                throw new TypeError('Parameter "func" must be of type "ChalkboardFunction" with a "type" property of "expl", "pola", "curv", "surf", or "mult".');
+        export const val = (func: ChalkboardFunction, x: number | ChalkboardVector): number | ChalkboardVector => {
+            if (func.field !== "real") {
+                throw new TypeError('Chalkboard.real.val: Property "field" of "func" must be "real".');
             }
+            if (func.type === "scalar2d") {
+                const f = func.rule as (x: number) => number;
+                return f(x as number);
+            } else if (func.type === "scalar3d") {
+                const f = func.rule as (x: number, y: number) => number;
+                const v = x as ChalkboardVector as { x: number, y: number };
+                return f(v.x, v.y);
+            } else if (func.type === "scalar4d") {
+                const f = func.rule as (x: number, y: number, z: number) => number;
+                const v = x as ChalkboardVector as { x: number, y: number, z: number };
+                return f(v.x, v.y, v.z);
+            } else if (func.type === "vector2d") {
+                const f = func.rule as [(x: number, y: number) => number, (x: number, y: number) => number];
+                const v = x as ChalkboardVector as { x: number, y: number };
+                return Chalkboard.vect.init(f[0](v.x, v.y), f[1](v.x, v.y));
+            } else if (func.type === "vector3d") {
+                const f = func.rule as [(x: number, y: number, z: number) => number, (x: number, y: number, z: number) => number, (x: number, y: number, z: number) => number];
+                const v = x as ChalkboardVector as { x: number, y: number, z: number };
+                return Chalkboard.vect.init(f[0](v.x, v.y, v.z), f[1](v.x, v.y, v.z), f[2](v.x, v.y, v.z));
+            } else if (func.type === "vector4d") {
+                const f = func.rule as [(x: number, y: number, z: number, w: number) => number, (x: number, y: number, z: number, w: number) => number, (x: number, y: number, z: number, w: number) => number, (x: number, y: number, z: number, w: number) => number];
+                const v = x as ChalkboardVector as { x: number, y: number, z: number, w: number };
+                return Chalkboard.vect.init(f[0](v.x, v.y, v.z, v.w), f[1](v.x, v.y, v.z, v.w), f[2](v.x, v.y, v.z, v.w), f[3](v.x, v.y, v.z, v.w));
+            } else if (func.type === "curve2d") {
+                const f = func.rule as [(t: number) => number, (t: number) => number];
+                const t = x as number;
+                return Chalkboard.vect.init(f[0](t), f[1](t));
+            } else if (func.type === "curve3d") {
+                const f = func.rule as [(t: number) => number, (t: number) => number, (t: number) => number];
+                const t = x as number;
+                return Chalkboard.vect.init(f[0](t), f[1](t), f[2](t));
+            } else if (func.type === "curve4d") {
+                const f = func.rule as [(t: number) => number, (t: number) => number, (t: number) => number, (t: number) => number];
+                const t = x as number;
+                return Chalkboard.vect.init(f[0](t), f[1](t), f[2](t), f[3](t));
+            } else if (func.type === "surface3d") {
+                const f = func.rule as [(s: number, t: number) => number, (s: number, t: number) => number, (s: number, t: number) => number];
+                const v = x as ChalkboardVector as { x: number, y: number };
+                return Chalkboard.vect.init(f[0](v.x, v.y), f[1](v.x, v.y), f[2](v.x, v.y));
+            }
+            throw new TypeError('Chalkboard.real.val: Property "type" of "func" is not supported.');
         };
 
         /**
          * Defines a zero function of a particular type.
-         * @param {"expl" | "inve" | "pola" | "curv" | "surf" | "mult"} [type="expl"] - The type of the function
+         * @param {"scalar2d" | "scalar3d" | "scalar4d" | "vector2d" | "vector3d" | "vector4d" | "curve2d" | "curve3d" | "curve4d" | "surface3d"} [type="scalar2d"] - The type of the function
          * @returns {ChalkboardFunction}
          */
-        export const zero = (type: "expl" | "inve" | "pola" | "curv" | "surf" | "mult" = "expl"): ChalkboardFunction => {
-            if (type === "expl" || type === "inve" || type === "pola" || type === "mult") {
-                return Chalkboard.real.define("0", type);
-            } else if (type === "curv") {
-                return Chalkboard.real.define(["0", "0"], type);
-            } else if (type === "surf") {
-                return Chalkboard.real.define(["0", "0", "0"], type);
+        export const zero = (type: "scalar2d" | "scalar3d" | "scalar4d" | "vector2d" | "vector3d" | "vector4d" | "curve2d" | "curve3d" | "curve4d" | "surface3d" = "scalar2d"): ChalkboardFunction => {
+            if (type === "scalar2d") {
+                return Chalkboard.real.define(() => 0, type);
+            } else if (type === "scalar3d") {
+                return Chalkboard.real.define(() => 0, type);
+            } else if (type === "scalar4d") {
+                return Chalkboard.real.define(() => 0, type);
+            } else if (type === "vector2d") {
+                return Chalkboard.real.define([() => 0, () => 0], type);
+            } else if (type === "vector3d") {
+                return Chalkboard.real.define([() => 0, () => 0, () => 0], type);
+            } else if (type === "vector4d") {
+                return Chalkboard.real.define([() => 0, () => 0, () => 0, () => 0], type);
+            } else if (type === "curve2d") {
+                return Chalkboard.real.define([() => 0, () => 0], type);
+            } else if (type === "curve3d") {
+                return Chalkboard.real.define([() => 0, () => 0, () => 0], type);
+            } else if (type === "curve4d") {
+                return Chalkboard.real.define([() => 0, () => 0, () => 0, () => 0], type);
+            } else if (type === "surface3d") {
+                return Chalkboard.real.define([() => 0, () => 0, () => 0], type);
             }
-            throw new TypeError('Parameter "type" must be either "expl", "inve", "pola", "curv", "surf", or "mult".');
+            throw new TypeError('Chalkboard.real.zero: Inputted "type" is not supported.');
         };
     }
 }

--- a/src/Chalkboard-real.ts
+++ b/src/Chalkboard-real.ts
@@ -19,28 +19,28 @@ namespace Chalkboard {
             if (func.type.startsWith("scalar")) {
                 const f = func.rule as ((...x: number[]) => number);
                 const g = (...x: number[]) => Math.abs(f(...x));
-                return Chalkboard.real.define(g, func.type);
+                return Chalkboard.real.define(g);
             } else if (func.type.startsWith("vector")) {
                 const f = func.rule as ((...x: number[]) => number)[];
                 const g = [];
                 for (let i = 0; i < f.length; i++) {
                     g.push((...x: number[]) => Math.abs(f[i](...x)));
                 }
-                return Chalkboard.real.define(g, func.type);
+                return Chalkboard.real.define(g);
             } else if (func.type.startsWith("curve")) {
                 const f = func.rule as ((t: number) => number)[];
                 const g = [];
                 for (let i = 0; i < f.length; i++) {
                     g.push((t: number) => Math.abs(f[i](t)));
                 }
-                return Chalkboard.real.define(g, func.type);
+                return Chalkboard.real.define(g);
             } else if (func.type.startsWith("surface")) {
                 const f = func.rule as ((s: number, t: number) => number)[];
                 const g = [];
                 for (let i = 0; i < f.length; i++) {
                     g.push((s: number, t: number) => Math.abs(f[i](s, t)));
                 }
-                return Chalkboard.real.define(g, func.type);
+                return Chalkboard.real.define(g);
             }
             throw new TypeError("Chalkboard.real.absolute: Property 'type' of 'func' must be 'scalar2d', 'scalar3d', 'scalar4d', 'vector2d', 'vector3d', 'vector4d', 'curve2d', 'curve3d', 'curve4d', or 'surface3d'.");
         };
@@ -58,7 +58,7 @@ namespace Chalkboard {
                 const f1 = func1.rule as ((...x: number[]) => number);
                 const f2 = func2.rule as ((...x: number[]) => number);
                 const g = (...x: number[]) => f1(...x) + f2(...x);
-                return Chalkboard.real.define(g, func1.type);
+                return Chalkboard.real.define(g);
             } else if (func1.type.startsWith("vector")) {
                 const f1 = func1.rule as ((...x: number[]) => number)[];
                 const f2 = func2.rule as ((...x: number[]) => number)[];
@@ -66,7 +66,7 @@ namespace Chalkboard {
                 for (let i = 0; i < f1.length; i++) {
                     g.push((...x: number[]) => f1[i](...x) + f2[i](...x));
                 }
-                return Chalkboard.real.define(g, func1.type);
+                return Chalkboard.real.define(g);
             } else if (func1.type.startsWith("curve")) {
                 const f1 = func1.rule as ((t: number) => number)[];
                 const f2 = func2.rule as ((t: number) => number)[];
@@ -74,7 +74,7 @@ namespace Chalkboard {
                 for (let i = 0; i < f1.length; i++) {
                     g.push((t: number) => f1[i](t) + f2[i](t));
                 }
-                return Chalkboard.real.define(g, func1.type);
+                return Chalkboard.real.define(g);
             } else if (func1.type.startsWith("surface")) {
                 const f1 = func1.rule as ((s: number, t: number) => number)[];
                 const f2 = func2.rule as ((s: number, t: number) => number)[];
@@ -82,7 +82,7 @@ namespace Chalkboard {
                 for (let i = 0; i < f1.length; i++) {
                     g.push((s: number, t: number) => f1[i](s, t) + f2[i](s, t));
                 }
-                return Chalkboard.real.define(g, func1.type);
+                return Chalkboard.real.define(g);
             }
             throw new TypeError("Chalkboard.real.add: Properties 'type' of 'func1' and 'func2' must be 'scalar2d', 'scalar3d', 'scalar4d', 'vector2d', 'vector3d', 'vector4d', 'curve2d', 'curve3d', 'curve4d', or 'surface3d'.");
         };
@@ -100,7 +100,7 @@ namespace Chalkboard {
                 const f1 = func1.rule as ((...x: number[]) => number);
                 const f2 = func2.rule as ((...x: number[]) => number);
                 const g = (...x: number[]) => f1(f2(...x));
-                return Chalkboard.real.define(g, func1.type);
+                return Chalkboard.real.define(g);
             } else if (func1.type.startsWith("vector")) {
                 const f1 = func1.rule as ((...x: number[]) => number)[];
                 const f2 = func2.rule as ((...x: number[]) => number)[];
@@ -108,7 +108,7 @@ namespace Chalkboard {
                 for (let i = 0; i < f1.length; i++) {
                     g.push((...x: number[]) => f1[i](f2[i](...x)));
                 }
-                return Chalkboard.real.define(g, func1.type);
+                return Chalkboard.real.define(g);
             }
             throw new TypeError("Chalkboard.real.compose: Properties 'type' of 'func1' and 'func2' must be 'scalar2d', 'scalar3d', 'scalar4d', 'vector2d', 'vector3d', or 'vector4d'.");
         };
@@ -116,58 +116,58 @@ namespace Chalkboard {
         /**
          * Defines a mathematical function in the field of real numbers.
          * @param {Function | Function[]} rule - The rule(s) of the function
-         * @param {"scalar2d" | "scalar3d" | "scalar4d" | "vector2d" | "vector3d" | "vector4d" | "curve2d" | "curve3d" | "curve4d" | "surface3d"} [type="scalar2d"] - The type of the function (optional, automatically configured if not explicitly provided)
          * @returns {ChalkboardFunction}
          */
-        export const define = (
-            rule: ((...x: number[]) => number) | (((...x: number[]) => number)[]),
-            type: "scalar2d" | "scalar3d" | "scalar4d" | "vector2d" | "vector3d" | "vector4d" | "curve2d" | "curve3d" | "curve4d" | "surface3d" = "scalar2d"
-        ): ChalkboardFunction => {
-            if (!type) {
-                if (Array.isArray(rule)) {
-                    const f = rule[0];
-                    if (rule.length === 2) {
-                        if (f.length === 1) {
-                            type = "curve2d";
-                        } else if (f.length === 2) {
-                            type = "vector2d";
-                        } else {
-                            throw new TypeError("Chalkboard.real.define: Functions in array 'rule' must have one variable to define a parametric curve or two variables to define a vector field.");
-                        }
-                    } else if (rule.length === 3) {
-                        if (f.length === 1) {
-                            type = "curve3d";
-                        } else if (f.length === 2) {
-                            type = "surface3d";
-                        } else if (f.length === 3) {
-                            type = "vector3d";
-                        } else {
-                            throw new TypeError("Chalkboard.real.define: Functions in array 'rule' must have one variable to define a parametric curve, two variables to define a parametric surface, or three variables to define a vector field.");
-                        }
-                    } else if (rule.length === 4) {
-                        if (f.length === 1) {
-                            type = "curve4d";
-                        } else if (f.length === 4) {
-                            type = "vector4d";
-                        } else {
-                            throw new TypeError("Chalkboard.real.define: Functions in array 'rule' must have one variable to define a parametric curve or four variables to define a vector field.");
-                        }
-                    }
-                } else {
-                    const f = rule as (...x: number[]) => number;
-                    if (f.length === 1) {
-                        type = "scalar2d";
-                    } else if (f.length === 2) {
-                        type = "scalar3d";
-                    } else if (f.length === 3) {
-                        type = "scalar4d";
+        export const define = (...rule: (((...x: number[]) => number) | ((...x: number[]) => number)[])[]): ChalkboardFunction => {
+            let f: ((...x: number[]) => number) | ((...x: number[]) => number)[];
+            let type: "scalar2d" | "scalar3d" | "scalar4d" | "vector2d" | "vector3d" | "vector4d" | "curve2d" | "curve3d" | "curve4d" | "surface3d" = "scalar2d";
+            if (rule.length === 1 && Array.isArray(rule[0])) {
+                f = rule[0] as ((...x: number[]) => number)[];
+            } else if (rule.length > 1) {
+                f = rule as ((...x: number[]) => number)[];
+            } else {
+                f = rule[0] as ((...x: number[]) => number);
+            }
+            if (Array.isArray(f)) {
+                if (f.length === 2) {
+                    if (f[0].length === 1) {
+                        type = "curve2d";
+                    } else if (f[0].length === 2) {
+                        type = "vector2d";
                     } else {
-                        throw new TypeError("Chalkboard.real.define: Function 'rule' must have one, two, or three variables to define a scalar function.");
+                        throw new TypeError("Chalkboard.real.define: Functions in array 'rule' must have one variable to define a parametric curve or two variables to define a vector field.");
+                    }
+                } else if (f.length === 3) {
+                    if (f[0].length === 1) {
+                        type = "curve3d";
+                    } else if (f[0].length === 2) {
+                        type = "surface3d";
+                    } else if (f[0].length === 3) {
+                        type = "vector3d";
+                    } else {
+                        throw new TypeError("Chalkboard.real.define: Functions in array 'rule' must have one variable to define a parametric curve, two variables to define a parametric surface, or three variables to define a vector field.");
+                    }
+                } else if (f.length === 4) {
+                    if (f[0].length === 1) {
+                        type = "curve4d";
+                    } else if (f[0].length === 4) {
+                        type = "vector4d";
+                    } else {
+                        throw new TypeError("Chalkboard.real.define: Functions in array 'rule' must have one variable to define a parametric curve or four variables to define a vector field.");
                     }
                 }
+            } else {
+                if (f.length === 1) {
+                    type = "scalar2d";
+                } else if (f.length === 2) {
+                    type = "scalar3d";
+                } else if (f.length === 3) {
+                    type = "scalar4d";
+                } else {
+                    throw new TypeError("Chalkboard.real.define: Function 'rule' must have one, two, or three variables to define a scalar function.");
+                }
             }
-            type = type || "scalar2d";
-            return { rule, field: "real", type } as ChalkboardFunction;
+            return { rule: f, field: "real", type } as ChalkboardFunction;
         };
 
         /**
@@ -216,7 +216,7 @@ namespace Chalkboard {
                 const f1 = func1.rule as ((...x: number[]) => number);
                 const f2 = func2.rule as ((...x: number[]) => number);
                 const g = (...x: number[]) => f1(...x) / f2(...x);
-                return Chalkboard.real.define(g, func1.type);
+                return Chalkboard.real.define(g);
             } else if (func1.type.startsWith("vector")) {
                 const f1 = func1.rule as ((...x: number[]) => number)[];
                 const f2 = func2.rule as ((...x: number[]) => number)[];
@@ -224,7 +224,7 @@ namespace Chalkboard {
                 for (let i = 0; i < f1.length; i++) {
                     g.push((...x: number[]) => f1[i](...x) / f2[i](...x));
                 }
-                return Chalkboard.real.define(g, func1.type);
+                return Chalkboard.real.define(g);
             } else if (func1.type.startsWith("curve")) {
                 const f1 = func1.rule as ((t: number) => number)[];
                 const f2 = func2.rule as ((t: number) => number)[];
@@ -232,7 +232,7 @@ namespace Chalkboard {
                 for (let i = 0; i < f1.length; i++) {
                     g.push((t: number) => f1[i](t) / f2[i](t));
                 }
-                return Chalkboard.real.define(g, func1.type);
+                return Chalkboard.real.define(g);
             } else if (func1.type.startsWith("surface")) {
                 const f1 = func1.rule as ((s: number, t: number) => number)[];
                 const f2 = func2.rule as ((s: number, t: number) => number)[];
@@ -240,7 +240,7 @@ namespace Chalkboard {
                 for (let i = 0; i < f1.length; i++) {
                     g.push((s: number, t: number) => f1[i](s, t) / f2[i](s, t));
                 }
-                return Chalkboard.real.define(g, func1.type);
+                return Chalkboard.real.define(g);
             }
             throw new TypeError("Chalkboard.real.div: Properties 'type' of 'func1' and 'func2' must be 'scalar2d', 'scalar3d', 'scalar4d', 'vector2d', 'vector3d', 'vector4d', 'curve2d', 'curve3d', 'curve4d', or 'surface3d'.");
         };
@@ -341,7 +341,7 @@ namespace Chalkboard {
                 const f1 = func1.rule as ((...x: number[]) => number);
                 const f2 = func2.rule as ((...x: number[]) => number);
                 const g = (...x: number[]) => f1(...x) * f2(...x);
-                return Chalkboard.real.define(g, func1.type);
+                return Chalkboard.real.define(g);
             } else if (func1.type.startsWith("vector")) {
                 const f1 = func1.rule as ((...x: number[]) => number)[];
                 const f2 = func2.rule as ((...x: number[]) => number)[];
@@ -349,7 +349,7 @@ namespace Chalkboard {
                 for (let i = 0; i < f1.length; i++) {
                     g.push((...x: number[]) => f1[i](...x) * f2[i](...x));
                 }
-                return Chalkboard.real.define(g, func1.type);
+                return Chalkboard.real.define(g);
             } else if (func1.type.startsWith("curve")) {
                 const f1 = func1.rule as ((t: number) => number)[];
                 const f2 = func2.rule as ((t: number) => number)[];
@@ -357,7 +357,7 @@ namespace Chalkboard {
                 for (let i = 0; i < f1.length; i++) {
                     g.push((t: number) => f1[i](t) * f2[i](t));
                 }
-                return Chalkboard.real.define(g, func1.type);
+                return Chalkboard.real.define(g);
             } else if (func1.type.startsWith("surface")) {
                 const f1 = func1.rule as ((s: number, t: number) => number)[];
                 const f2 = func2.rule as ((s: number, t: number) => number)[];
@@ -365,7 +365,7 @@ namespace Chalkboard {
                 for (let i = 0; i < f1.length; i++) {
                     g.push((s: number, t: number) => f1[i](s, t) * f2[i](s, t));
                 }
-                return Chalkboard.real.define(g, func1.type);
+                return Chalkboard.real.define(g);
             }
             throw new TypeError("Chalkboard.real.mul: Properties 'type' of 'func1' and 'func2' must be 'scalar2d', 'scalar3d', 'scalar4d', 'vector2d', 'vector3d', 'vector4d', 'curve2d', 'curve3d', 'curve4d', or 'surface3d'.");
         };
@@ -380,28 +380,28 @@ namespace Chalkboard {
             if (func.type.startsWith("scalar")) {
                 const f = func.rule as ((...x: number[]) => number);
                 const g = (...x: number[]) => -f(...x);
-                return Chalkboard.real.define(g, func.type);
+                return Chalkboard.real.define(g);
             } else if (func.type.startsWith("vector")) {
                 const f = func.rule as ((...x: number[]) => number)[];
                 const g = [];
                 for (let i = 0; i < f.length; i++) {
                     g.push((...x: number[]) => -f[i](...x));
                 }
-                return Chalkboard.real.define(g, func.type);
+                return Chalkboard.real.define(g);
             } else if (func.type.startsWith("curve")) {
                 const f = func.rule as ((t: number) => number)[];
                 const g = [];
                 for (let i = 0; i < f.length; i++) {
                     g.push((t: number) => -f[i](t));
                 }
-                return Chalkboard.real.define(g, func.type);
+                return Chalkboard.real.define(g);
             } else if (func.type.startsWith("surface")) {
                 const f = func.rule as ((s: number, t: number) => number)[];
                 const g = [];
                 for (let i = 0; i < f.length; i++) {
                     g.push((s: number, t: number) => -f[i](s, t));
                 }
-                return Chalkboard.real.define(g, func.type);
+                return Chalkboard.real.define(g);
             }
             throw new TypeError("Chalkboard.real.negate: Property 'type' of 'func' must be 'scalar2d', 'scalar3d', 'scalar4d', 'vector2d', 'vector3d', 'vector4d', 'curve2d', 'curve3d', 'curve4d', or 'surface3d'.");
         };
@@ -475,28 +475,28 @@ namespace Chalkboard {
                 if (func.type.startsWith("scalar")) {
                     const f = func.rule as ((...x: number[]) => number);
                     const g = (...x: number[]) => f(...x) ** num;
-                    return Chalkboard.real.define(g, func.type);
+                    return Chalkboard.real.define(g);
                 } else if (func.type.startsWith("vector")) {
                     const f = func.rule as ((...x: number[]) => number)[];
                     const g = [];
                     for (let i = 0; i < f.length; i++) {
                         g.push((...x: number[]) => f[i](...x) ** num);
                     }
-                    return Chalkboard.real.define(g, func.type);
+                    return Chalkboard.real.define(g);
                 } else if (func.type.startsWith("curve")) {
                     const f = func.rule as ((t: number) => number)[];
                     const g = [];
                     for (let i = 0; i < f.length; i++) {
                         g.push((t: number) => f[i](t) ** num);
                     }
-                    return Chalkboard.real.define(g, func.type);
+                    return Chalkboard.real.define(g);
                 } else if (func.type.startsWith("surface")) {
                     const f = func.rule as ((s: number, t: number) => number)[];
                     const g = [];
                     for (let i = 0; i < f.length; i++) {
                         g.push((s: number, t: number) => f[i](s, t) ** num);
                     }
-                    return Chalkboard.real.define(g, func.type);
+                    return Chalkboard.real.define(g);
                 }
                 throw new TypeError("Chalkboard.real.pow: Property 'type' of 'func' must be 'scalar2d', 'scalar3d', 'scalar4d', 'vector2d', 'vector3d', 'vector4d', 'curve2d', 'curve3d', 'curve4d', or 'surface3d'.");
             }
@@ -595,28 +595,28 @@ namespace Chalkboard {
             if (func.type.startsWith("scalar")) {
                 const f = func.rule as ((...x: number[]) => number);
                 const g = (...x: number[]) => 1 / f(...x);
-                return Chalkboard.real.define(g, func.type);
+                return Chalkboard.real.define(g);
             } else if (func.type.startsWith("vector")) {
                 const f = func.rule as ((...x: number[]) => number)[];
                 const g = [];
                 for (let i = 0; i < f.length; i++) {
                     g.push((...x: number[]) => 1 / f[i](...x));
                 }
-                return Chalkboard.real.define(g, func.type);
+                return Chalkboard.real.define(g);
             } else if (func.type.startsWith("curve")) {
                 const f = func.rule as ((t: number) => number)[];
                 const g = [];
                 for (let i = 0; i < f.length; i++) {
                     g.push((t: number) => 1 / f[i](t));
                 }
-                return Chalkboard.real.define(g, func.type);
+                return Chalkboard.real.define(g);
             } else if (func.type.startsWith("surface")) {
                 const f = func.rule as ((s: number, t: number) => number)[];
                 const g = [];
                 for (let i = 0; i < f.length; i++) {
                     g.push((s: number, t: number) => 1 / f[i](s, t));
                 }
-                return Chalkboard.real.define(g, func.type);
+                return Chalkboard.real.define(g);
             }
             throw new TypeError("Chalkboard.real.reciprocate: Property 'type' of 'func' must be 'scalar2d', 'scalar3d', 'scalar4d', 'vector2d', 'vector3d', 'vector4d', 'curve2d', 'curve3d', 'curve4d', or 'surface3d'.");
         };
@@ -658,28 +658,28 @@ namespace Chalkboard {
             if (func.type.startsWith("scalar")) {
                 const f = func.rule as ((...x: number[]) => number);
                 const g = (...x: number[]) => f(...x) * num;
-                return Chalkboard.real.define(g, func.type);
+                return Chalkboard.real.define(g);
             } else if (func.type.startsWith("vector")) {
                 const f = func.rule as ((...x: number[]) => number)[];
                 const g = [];
                 for (let i = 0; i < f.length; i++) {
                     g.push((...x: number[]) => f[i](...x) * num);
                 }
-                return Chalkboard.real.define(g, func.type);
+                return Chalkboard.real.define(g);
             } else if (func.type.startsWith("curve")) {
                 const f = func.rule as ((t: number) => number)[];
                 const g = [];
                 for (let i = 0; i < f.length; i++) {
                     g.push((t: number) => f[i](t) * num);
                 }
-                return Chalkboard.real.define(g, func.type);
+                return Chalkboard.real.define(g);
             } else if (func.type.startsWith("surface")) {
                 const f = func.rule as ((s: number, t: number) => number)[];
                 const g = [];
                 for (let i = 0; i < f.length; i++) {
                     g.push((s: number, t: number) => f[i](s, t) * num);
                 }
-                return Chalkboard.real.define(g, func.type);
+                return Chalkboard.real.define(g);
             }
             throw new TypeError("Chalkboard.real.scl: Property 'type' of 'func' must be 'scalar2d', 'scalar3d', 'scalar4d', 'vector2d', 'vector3d', 'vector4d', 'curve2d', 'curve3d', 'curve4d', or 'surface3d'.");
         };
@@ -722,7 +722,7 @@ namespace Chalkboard {
                 const f1 = func1.rule as ((...x: number[]) => number);
                 const f2 = func2.rule as ((...x: number[]) => number);
                 const g = (...x: number[]) => f1(...x) - f2(...x);
-                return Chalkboard.real.define(g, func1.type);
+                return Chalkboard.real.define(g);
             } else if (func1.type.startsWith("vector")) {
                 const f1 = func1.rule as ((...x: number[]) => number)[];
                 const f2 = func2.rule as ((...x: number[]) => number)[];
@@ -730,7 +730,7 @@ namespace Chalkboard {
                 for (let i = 0; i < f1.length; i++) {
                     g.push((...x: number[]) => f1[i](...x) - f2[i](...x));
                 }
-                return Chalkboard.real.define(g, func1.type);
+                return Chalkboard.real.define(g);
             } else if (func1.type.startsWith("curve")) {
                 const f1 = func1.rule as ((t: number) => number)[];
                 const f2 = func2.rule as ((t: number) => number)[];
@@ -738,7 +738,7 @@ namespace Chalkboard {
                 for (let i = 0; i < f1.length; i++) {
                     g.push((t: number) => f1[i](t) - f2[i](t));
                 }
-                return Chalkboard.real.define(g, func1.type);
+                return Chalkboard.real.define(g);
             } else if (func1.type.startsWith("surface")) {
                 const f1 = func1.rule as ((s: number, t: number) => number)[];
                 const f2 = func2.rule as ((s: number, t: number) => number)[];
@@ -746,7 +746,7 @@ namespace Chalkboard {
                 for (let i = 0; i < f1.length; i++) {
                     g.push((s: number, t: number) => f1[i](s, t) - f2[i](s, t));
                 }
-                return Chalkboard.real.define(g, func1.type);
+                return Chalkboard.real.define(g);
             }
             throw new TypeError("Chalkboard.real.sub: Properties 'type' of 'func1' and 'func2' must be 'scalar2d', 'scalar3d', 'scalar4d', 'vector2d', 'vector3d', 'vector4d', 'curve2d', 'curve3d', 'curve4d', or 'surface3d'.");
         };
@@ -777,7 +777,7 @@ namespace Chalkboard {
             if (func.type === "scalar2d") {
                 const f = func.rule as (x: number) => number;
                 const g = (x: number) => f(x - h) + v;
-                return Chalkboard.real.define(g, func.type);
+                return Chalkboard.real.define(g);
             }
             throw new TypeError("Chalkboard.real.translate: Property 'type' of 'func' must be 'scalar2d'.");
         };
@@ -841,25 +841,25 @@ namespace Chalkboard {
          */
         export const zero = (type: "scalar2d" | "scalar3d" | "scalar4d" | "vector2d" | "vector3d" | "vector4d" | "curve2d" | "curve3d" | "curve4d" | "surface3d" = "scalar2d"): ChalkboardFunction => {
             if (type === "scalar2d") {
-                return Chalkboard.real.define(() => 0, type);
+                return Chalkboard.real.define((x) => 0);
             } else if (type === "scalar3d") {
-                return Chalkboard.real.define(() => 0, type);
+                return Chalkboard.real.define((x, y) => 0);
             } else if (type === "scalar4d") {
-                return Chalkboard.real.define(() => 0, type);
+                return Chalkboard.real.define((x, y, z) => 0);
             } else if (type === "vector2d") {
-                return Chalkboard.real.define([() => 0, () => 0], type);
+                return Chalkboard.real.define((x, y) => 0, (x, y) => 0);
             } else if (type === "vector3d") {
-                return Chalkboard.real.define([() => 0, () => 0, () => 0], type);
+                return Chalkboard.real.define((x, y, z) => 0, (x, y, z) => 0, (x, y, z) => 0);
             } else if (type === "vector4d") {
-                return Chalkboard.real.define([() => 0, () => 0, () => 0, () => 0], type);
+                return Chalkboard.real.define((x, y, z, w) => 0, (x, y, z, w) => 0, (x, y, z, w) => 0, (x, y, z, w) => 0);
             } else if (type === "curve2d") {
-                return Chalkboard.real.define([() => 0, () => 0], type);
+                return Chalkboard.real.define((t) => 0, (t) => 0);
             } else if (type === "curve3d") {
-                return Chalkboard.real.define([() => 0, () => 0, () => 0], type);
+                return Chalkboard.real.define((t) => 0, (t) => 0, (t) => 0);
             } else if (type === "curve4d") {
-                return Chalkboard.real.define([() => 0, () => 0, () => 0, () => 0], type);
+                return Chalkboard.real.define((t) => 0, (t) => 0, (t) => 0, (t) => 0);
             } else if (type === "surface3d") {
-                return Chalkboard.real.define([() => 0, () => 0, () => 0], type);
+                return Chalkboard.real.define((s, t) => 0, (s, t) => 0, (s, t) => 0);
             }
             throw new TypeError("Chalkboard.real.zero: String 'type' must be 'scalar2d', 'scalar3d', 'scalar4d', 'vector2d', 'vector3d', 'vector4d', 'curve2d', 'curve3d', 'curve4d', or 'surface3d'.");
         };

--- a/src/Chalkboard-trig.ts
+++ b/src/Chalkboard-trig.ts
@@ -16,7 +16,7 @@ namespace Chalkboard {
          */
         export const arccos = (rad: number): number | undefined => {
             if (rad > -1 && rad < 1) {
-                return Chalkboard.calc.fxdx(Chalkboard.real.define("1 / (Math.sqrt(1 - x * x))"), rad, 1) as number;
+                return Chalkboard.calc.fxdx(Chalkboard.real.define((x) => 1 / (Math.sqrt(1 - x * x))), rad, 1) as number;
             } else if (rad === 1) {
                 return 0;
             } else if (rad === -1) {
@@ -45,7 +45,7 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const arccot = (rad: number): number => {
-            return Chalkboard.calc.fxdx(Chalkboard.real.define("1 / (1 + x * x)"), rad, 1000) as number;
+            return Chalkboard.calc.fxdx(Chalkboard.real.define((x) => 1 / (1 + x * x)), rad, 1000) as number;
         };
 
         /**
@@ -68,13 +68,13 @@ namespace Chalkboard {
          */
         export const arccsc = (rad: number): number | undefined => {
             if (rad > 1) {
-                return Chalkboard.calc.fxdx(Chalkboard.real.define("1 / (x * Math.sqrt(x * x - 1))"), rad, 1000) as number;
+                return Chalkboard.calc.fxdx(Chalkboard.real.define((x) => 1 / (x * Math.sqrt(x * x - 1))), rad, 1000) as number;
             } else if (rad === 1) {
                 return Chalkboard.PI() / 2;
             } else if (rad === -1) {
                 return -Chalkboard.PI() / 2;
             } else if (rad < 1) {
-                return -Chalkboard.calc.fxdx(Chalkboard.real.define("1 / (x * Math.sqrt(x * x - 1))"), Math.abs(rad), 1000);
+                return -Chalkboard.calc.fxdx(Chalkboard.real.define((x) => 1 / (x * Math.sqrt(x * x - 1))), Math.abs(rad), 1000);
             } else {
                 return undefined;
             }
@@ -100,7 +100,7 @@ namespace Chalkboard {
          */
         export const arcsec = (rad: number): number | undefined => {
             if (rad > 1) {
-                return Chalkboard.calc.fxdx(Chalkboard.real.define("1 / (x * Math.sqrt(x * x - 1))"), 1.000001, rad) as number;
+                return Chalkboard.calc.fxdx(Chalkboard.real.define((x) => 1 / (x * Math.sqrt(x * x - 1))), 1.000001, rad) as number;
             } else if (rad === 1) {
                 return 0;
             } else if (rad === -1) {
@@ -130,7 +130,7 @@ namespace Chalkboard {
          */
         export const arcsin = (rad: number): number | undefined => {
             if (rad > -1 && rad < 1) {
-                return Chalkboard.calc.fxdx(Chalkboard.real.define("1 / (Math.sqrt(1 - x * x))"), 0, rad) as number;
+                return Chalkboard.calc.fxdx(Chalkboard.real.define((x) => 1 / (Math.sqrt(1 - x * x))), 0, rad) as number;
             } else if (rad === 1) {
                 return Chalkboard.PI() / 2;
             } else if (rad === -1) {
@@ -155,7 +155,7 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const arctan = (rad: number): number => {
-            return Chalkboard.calc.fxdx(Chalkboard.real.define("1 / (1 + x * x)"), 0, rad) as number;
+            return Chalkboard.calc.fxdx(Chalkboard.real.define((x) => 1 / (1 + x * x)), 0, rad) as number;
         };
 
         /**

--- a/src/Chalkboard.ts
+++ b/src/Chalkboard.ts
@@ -23,12 +23,14 @@ type ChalkboardComplex = { a: number; b: number };
  * @property {string | string[]} domain - The domain of the function
  * @property {string | string[]} codomain - The codomain of the function
  * @property {"real" | "comp"} type - The type of the function, which can be "real" or "comp"
+ * @property {"scalar2d" | "scalar3d" | "vector2d" | "vector3d" | "vector4d" | "curve2d" | "curve3d" | "surface"} subtype - The subtype of the "real"-type function, which can be "scalar2d", "scalar3d", "vector2d", "vector3d", "vector4d", "curve2d", "curve3d", or "surface"
  */
 type ChalkboardFunction = {
     rule: ((...x: number[]) => number) | (((...x: number[]) => number)[]);
     domain: string | string[];
     codomain: string | string[];
     type: "real";
+    subtype: "scalar2d" | "scalar3d" | "vector2d" | "vector3d" | "vector4d" | "curve2d" | "curve3d" | "surface"
 } | {
     rule: [(z: ChalkboardComplex) => ChalkboardComplex, (z: ChalkboardComplex) => ChalkboardComplex];
     domain: string | string[];

--- a/src/Chalkboard.ts
+++ b/src/Chalkboard.ts
@@ -19,10 +19,22 @@ type ChalkboardComplex = { a: number; b: number };
 
 /**
  * The type for mathematical functions.
- * @property {string | string[]} definition - The function's definition
- * @property {"expl" | "inve" | "pola" | "curv" | "surf" | "mult" | "comp"} type - The function's type, which can be "expl" for explicit functions, "inve" for inverse functions, "pola" for polar functions, "curv" for parametric curves, "surf" for parametric surfaces, "mult" for explicit multivariable functions, or "comp" for explicit complex-valued functions
+ * @property {Function | Function[]} rule - The rule of the function
+ * @property {string | string[]} domain - The domain of the function
+ * @property {string | string[]} codomain - The codomain of the function
+ * @property {"real" | "comp"} type - The type of the function, which can be "real" or "comp"
  */
-type ChalkboardFunction = { definition: string | string[]; type: "expl" | "inve" | "pola" | "curv" | "surf" | "mult" | "comp" };
+type ChalkboardFunction = {
+    rule: ((...x: number[]) => number) | (((...x: number[]) => number)[]);
+    domain: string | string[];
+    codomain: string | string[];
+    type: "real";
+} | {
+    rule: [(z: ChalkboardComplex) => ChalkboardComplex, (z: ChalkboardComplex) => ChalkboardComplex];
+    domain: string | string[];
+    codomain: string | string[];
+    type: "comp";
+};
 
 /**
  * The type for matrices.
@@ -125,15 +137,6 @@ type ChalkboardTensor = number | ChalkboardTensor[];
  * @property {number} [w] - The w-component (defined for 4D vectors)
  */
 type ChalkboardVector = { x: number; y: number; z?: number; w?: number } | number[] | Float32Array | Float64Array | ChalkboardMatrix | string;
-
-/**
- * The type for vector fields.
- * @property {string} p - The x-component (defined for 2D, 3D, and 4D vector fields)
- * @property {string} q - The y-component (defined for 2D, 3D, and 4D vector fields)
- * @property {string} [r] - The z-component (defined for 3D and 4D vector fields)
- * @property {string} [s] - The w-component (defined for 4D vector fields)
- */
-type ChalkboardVectorField = { p: string; q: string; r?: string; s?: string };
 
 /**
  * The Chalkboard library namespace.

--- a/src/Chalkboard.ts
+++ b/src/Chalkboard.ts
@@ -24,7 +24,7 @@ type ChalkboardComplex = { a: number; b: number };
  * @property {"scalar2d" | "scalar3d" | "scalar4d" | "vector2d" | "vector3d" | "vector4d" | "curve2d" | "curve3d" | "curve4d" | "surface3d"} type - The type of the function
  */
 type ChalkboardFunction = {
-    rule: ((...x: number[]) => number) | (((...x: number[]) => number)[]) | ((...x: ChalkboardComplex[]) => ChalkboardComplex) | (((...x: ChalkboardComplex[]) => ChalkboardComplex)[]);
+    rule: ((...x: number[]) => number) | (((...x: number[]) => number)[]);
     field: "real" | "comp";
     type: "scalar2d" | "scalar3d" | "scalar4d" | "vector2d" | "vector3d" | "vector4d" | "curve2d" | "curve3d" | "curve4d" | "surface3d"
 };

--- a/src/Chalkboard.ts
+++ b/src/Chalkboard.ts
@@ -20,22 +20,13 @@ type ChalkboardComplex = { a: number; b: number };
 /**
  * The type for mathematical functions.
  * @property {Function | Function[]} rule - The rule of the function
- * @property {string | string[]} domain - The domain of the function
- * @property {string | string[]} codomain - The codomain of the function
- * @property {"real" | "comp"} type - The type of the function, which can be "real" or "comp"
- * @property {"scalar2d" | "scalar3d" | "vector2d" | "vector3d" | "vector4d" | "curve2d" | "curve3d" | "surface"} subtype - The subtype of the "real"-type function, which can be "scalar2d", "scalar3d", "vector2d", "vector3d", "vector4d", "curve2d", "curve3d", or "surface"
+ * @property {"real" | "comp"} field - The field of the function, which can be "real" for the field of real numbers or "comp" for the field of complex numbers
+ * @property {"scalar2d" | "scalar3d" | "scalar4d" | "vector2d" | "vector3d" | "vector4d" | "curve2d" | "curve3d" | "curve4d" | "surface3d"} type - The type of the function
  */
 type ChalkboardFunction = {
-    rule: ((...x: number[]) => number) | (((...x: number[]) => number)[]);
-    domain: string | string[];
-    codomain: string | string[];
-    type: "real";
-    subtype: "scalar2d" | "scalar3d" | "vector2d" | "vector3d" | "vector4d" | "curve2d" | "curve3d" | "surface"
-} | {
-    rule: [(z: ChalkboardComplex) => ChalkboardComplex, (z: ChalkboardComplex) => ChalkboardComplex];
-    domain: string | string[];
-    codomain: string | string[];
-    type: "comp";
+    rule: ((...x: number[]) => number) | (((...x: number[]) => number)[]) | ((...x: ChalkboardComplex[]) => ChalkboardComplex) | (((...x: ChalkboardComplex[]) => ChalkboardComplex)[]);
+    field: "real" | "comp";
+    type: "scalar2d" | "scalar3d" | "scalar4d" | "vector2d" | "vector3d" | "vector4d" | "curve2d" | "curve3d" | "curve4d" | "surface3d"
 };
 
 /**


### PR DESCRIPTION
Changed everything in the library related to `ChalkboardFunction` such that it now uses native JavaScript function references (`rule` property) instead of string-based definitions (`definition` property).
Furthermore, the types of functions (e.g. `expl`, `pola`, `curv`, etc.) are now automatically configured instead of needing to be explicitly provided. They have also been renamed to be more descriptive (e.g. `expl` changed to `scalar2d`, `mult` changed to `scalar3d`, `curv` changed to `curve2d`, etc.).
Additionally, `ChalkboardVectorField` has been removed and replaced with `ChalkboardFunction` (of types `vector2d`, `vector3d`, and `vector4d`), although either `real.define` or `vect.field` are still available to be used to define vector fields.
Also, the `field` property has been added to `ChalkboardFunction` to explicitly differentiate functions in the field of real numbers from functions in the field of complex numbers ("field" here refers to the algebraic structure, not the function type of vector fields).
Talking about functions in the field of complex numbers, they can now be defined with `comp.define` in two different ways: two functions of two variables that denote the real and imaginary parts of the function as they take two real numbers and return a real number (old feature) or one function of one variable that denotes an explicit complex function as it takes one complex number and returns a complex number (new feature).
Lastly, since the function types are automatically configured based on the function signatures instead of explicitly inputted by strings, the `config` parameter of `plot.definition` has two new options which are `isInverse` and `isPolar` (and `plot.dfdx`, `plot.d2fdx2`, `plot.fxdx` also have the `isInverse` option) so that plotting inverse and polar functions is still available with the new `scalar2d` function type that replaced the `inve` and `pola` types.

As an overview, this is an example of how mathematical functions are defined in Chalkboard v2.4.0 and older:
```js
const cb = Chalkboard;
const f = cb.real.define("x**2 + 2*x + 1"); // f(x) = x^2 + 2x + 1
const g = cb.real.define("x**2 - y**2", "mult"); // g(x, y) = x^2 - y^2
const r = cb.real.define(["Math.cos(t)", "Math.sin(t)"], "curv"); // r(t) = (cost, sint)
const p = cb.comp.define("a*a - b*b", "2*a*b"); // p(z) = z^2
const v = cb.vect.field("-y", "x"); // v(x, y) = (-y, x)
```
And this is how they will be defined in Chalkboard v3.0.0 and later:
```js
const cb = Chalkboard;
const f = cb.real.define((x) => x**2 + 2*x + 1); // f(x) = x^2 + 2x + 1
const g = cb.real.define((x, y) => x**2 - y**2); // g(x, y) = x^2 - y^2
const r = cb.real.define((t) => cb.trig.cos(t), (t) => cb.trig.sin(t)); // r(t) = (cost, sint)
const p = cb.comp.define((z) => cb.comp.sq(z)); // p(z) = z^2
const v = cb.real.define((x, y) => -y, (x, y) => x); // v(x, y) = (-y, x)
```
This is a notably beneficial update as it significantly enhances functionality (pun intended) of functions since now they can be defined by Chalkboard functions (not only native JavaScript operators and `Math` functions) like `numb.factorial`, `real.Dirac`, or `trig.arccsch`, plus it improves performance by eliminating overhead from string parsing and evaluation, increases type safety by implementing full TypeScript support with proper function signatures, and facilitates debugging by making it easier to trace through function executions with actual functions.