### PR TITLE
Introduce differential equations plus miscellaneous changes

### DIFF
--- a/src/Chalkboard-bool.ts
+++ b/src/Chalkboard-bool.ts
@@ -608,13 +608,18 @@ namespace Chalkboard {
                         return node.name;
                     }
                     case "not": {
-                        return `\\neg ${nodeToLaTeX(node.expr)}`;
+                        const inner = (node.expr.type === "var" || node.expr.type === "bool") ? nodeToLaTeX(node.expr) : `\\left(${nodeToLaTeX(node.expr)}\\right)`;
+                        return `\\neg ${inner}`;
                     }
                     case "and": {
-                        return `${nodeToLaTeX(node.left)} \\land ${nodeToLaTeX(node.right)}`;
+                        const left = node.left.type === "or" ? `\\left(${nodeToLaTeX(node.left)}\\right)` : nodeToLaTeX(node.left);
+                        const right = node.right.type === "or" ? `\\left(${nodeToLaTeX(node.right)}\\right)` : nodeToLaTeX(node.right);
+                        return `${left} \\land ${right}`;
                     }
                     case "or": {
-                        return `${nodeToLaTeX(node.left)} \\lor ${nodeToLaTeX(node.right)}`;
+                        const left = node.left.type === "and" ? `\\left(${nodeToLaTeX(node.left)}\\right)` : nodeToLaTeX(node.left);
+                        const right = node.right.type === "and" ? `\\left(${nodeToLaTeX(node.right)}\\right)` : nodeToLaTeX(node.right);
+                        return `${left} \\lor ${right}`;
                     }
                     default: {
                         throw new Error(`Chalkboard.bool.parse: Unknown node type ${node.type}`);

--- a/src/Chalkboard-comp.ts
+++ b/src/Chalkboard-comp.ts
@@ -424,29 +424,18 @@ namespace Chalkboard {
                         i++;
                         continue;
                     }
-                    if ("+-*/(),".indexOf(ch) !== -1) {
+                    if ("+-*/(),^".indexOf(ch) !== -1) {
                         tokens.push(ch);
                         i++;
-                        if (ch === ")" && i < input.length && (/[a-zA-Z0-9_i]/.test(input[i]))) tokens.push("*");
-                    } else if (ch === "^") {
-                        tokens.push(ch);
-                        i++;
-                        if (i < input.length && input[i] === "-") {
-                            let num = "-";
-                            i++;
-                            while (i < input.length && /[0-9.]/.test(input[i])) {
-                                num += input[i++];
-                            }
-                            if (num !== "-") {
-                                tokens.push(num);
-                            } else {
-                                tokens.push("-");
-                            }
+                        if (ch === ")" && i < input.length && (/[a-zA-Z0-9_i(]/.test(input[i]))) {
+                            if (tokens[tokens.length - 1] !== "*") tokens.push("*");
                         }
                     } else if (ch === "i" && (i === 0 || !/[a-zA-Z0-9_]/.test(input[i - 1]))) {
                         tokens.push("i");
                         i++;
-                        if (i < input.length && (/[a-zA-Z0-9_(]/.test(input[i]))) tokens.push("*");
+                        if (i < input.length && (/[a-zA-Z0-9_(]/.test(input[i]))) {
+                            if (tokens[tokens.length - 1] !== "*") tokens.push("*");
+                        }
                     } else if (/[0-9]/.test(ch) || (ch === "." && /[0-9]/.test(input[i + 1]))) {
                         let num = "";
                         let hasDecimal = false;
@@ -456,23 +445,32 @@ namespace Chalkboard {
                         }
                         tokens.push(num);
                         if (i < input.length && input[i] === "i") {
-                            tokens.push("*");
+                            if (tokens[tokens.length - 1] !== "*") tokens.push("*");
                             tokens.push("i");
                             i++;
                         }
-                        if (i < input.length && (/[a-zA-Z_]/.test(input[i]) || input[i] === "(")) tokens.push("*");
+                        if (i < input.length && (/[a-zA-Z_]/.test(input[i]) || input[i] === "(")) {
+                            if (tokens[tokens.length - 1] !== "*") tokens.push("*");
+                        }
                     } else if (/[a-zA-Z_]/.test(ch)) {
                         let name = "";
                         while (i < input.length && /[a-zA-Z0-9_]/.test(input[i])) {
                             name += input[i++];
                         }
-                        tokens.push(name);
+                        if (/^[a-zA-Z]+$/.test(name) && name.length > 1 && !isFunction(name)) {
+                            for (let j = 0; j < name.length; j++) {
+                                tokens.push(name[j]);
+                                if (j < name.length - 1) tokens.push("*");
+                            }
+                        } else {
+                            tokens.push(name);
+                        }
                         if (i < input.length && input[i] === "(") {
                             if (!isFunction(name)) {
-                                tokens.push("*");
+                                if (tokens[tokens.length - 1] !== "*") tokens.push("*");
                             }
                         } else if (i < input.length && (/[a-zA-Z_]/.test(input[i]))) {
-                            tokens.push("*");
+                            if (tokens[tokens.length - 1] !== "*") tokens.push("*");
                         }
                     } else {
                         throw new Error(`Chalkboard.comp.parse: Unexpected character ${ch}`);
@@ -509,7 +507,7 @@ namespace Chalkboard {
                 const parseUnary = (): { type: string, [key: string]: any } => {
                     if (peek() === "-") {
                         consume("-");
-                        return { type: "neg", expr: parseExponent() }; 
+                        return { type: "neg", expr: parseExponent() };
                     } else if (peek() === "+") {
                         consume("+");
                         return parseExponent();
@@ -520,10 +518,15 @@ namespace Chalkboard {
                     let node = parsePrimary();
                     if (peek() === "^") {
                         consume("^");
-                        const right = parseExponent(); 
+                        const right = parseExponentUnary();
                         node = { type: "pow", base: node, exponent: right };
                     }
                     return node;
+                };
+                const parseExponentUnary = (): { type: string, [key: string]: any } => {
+                    if (peek() === "-") { consume("-"); return { type:"neg", expr: parseExponentUnary() }; }
+                    if (peek() === "+") { consume("+"); return parseExponentUnary(); }
+                    return parseExponent();
                 };
                 const parsePrimary = (): { type: string, [key: string]: any } => {
                     const token = peek();
@@ -575,18 +578,6 @@ namespace Chalkboard {
                     case "var": {
                         const varname = node.name;
                         if (varname in values) return values[varname];
-                        for (let i = 1; i < varname.length; i++) {
-                            const left = varname.substring(0, i);
-                            const right = varname.substring(i);
-                            if (left in values) {
-                                try {
-                                    const rightResult = evaluateNode({ type: "var", name: right }, values);
-                                    return Chalkboard.comp.mul(values[left], rightResult) as ChalkboardComplex;
-                                } catch {
-                                    continue;
-                                }
-                            }
-                        }
                         throw new Error(`Chalkboard.comp.parse: Variable '${varname}' not defined in values`);
                     }
                     case "add": {
@@ -627,9 +618,7 @@ namespace Chalkboard {
                             } catch (e) {}
                         }
                         switch (funcName) {
-                            case "conj": {
-                                return Chalkboard.comp.conjugate(args[0]) as ChalkboardComplex;
-                            }
+                            case "conj":
                             case "conjugate": {
                                 return Chalkboard.comp.conjugate(args[0]) as ChalkboardComplex;
                             }
@@ -675,6 +664,11 @@ namespace Chalkboard {
                 }
                 throw new Error(`Chalkboard.comp.parse: Unknown node type ${node.type}`);
             };
+            const needsParensInPow = (z: { a: number, b: number }): boolean => {
+                if (z.b === 0) return false;
+                if (z.a === 0 && (z.b === 1 || z.b === -1)) return false;
+                return true;
+            };
             const nodeToString = (node: { type: string, [key: string]: any }): string => {
                 switch (node.type) {
                     case "num": {
@@ -691,16 +685,21 @@ namespace Chalkboard {
                         return node.name;
                     }
                     case "add": {
-                        return `${nodeToString(node.left)} + ${nodeToString(node.right)}`;
+                        const rightStr = nodeToString(node.right);
+                        if (rightStr.startsWith("-")) return `${nodeToString(node.left)} - ${rightStr.slice(1)}`;
+                        return `${nodeToString(node.left)} + ${rightStr}`;
                     }
                     case "sub": {
                         const rightStr = node.right.type === "add" || node.right.type === "sub" ? `(${nodeToString(node.right)})` : nodeToString(node.right);
                         return `${nodeToString(node.left)} - ${rightStr}`;
                     }
                     case "mul": {
+                        if (node.left.type === "num" && node.left.value === 1) return nodeToString(node.right);
+                        if (node.right.type === "num" && node.right.value === 1) return nodeToString(node.left);
                         const leftMul = (node.left.type === "add" || node.left.type === "sub") ? `(${nodeToString(node.left)})` : nodeToString(node.left);
                         const rightMul = (node.right.type === "add" || node.right.type === "sub") ? `(${nodeToString(node.right)})` : nodeToString(node.right);
                         if (node.left.type === "num" && node.left.value === -1 && node.right.type === "var") return `-${nodeToString(node.right)}`;
+                        if (node.left.type === "num" && node.left.value === -1 && node.right.type === "pow") return `-${nodeToString(node.right)}`;
                         if ((node.left.type === "num" || node.left.type === "complex") && (node.right.type === "var" || (node.right.type === "complex" && node.right.a === 0 && node.right.b === 1))) {
                             return `${leftMul}${rightMul}`;
                         } else {
@@ -713,7 +712,15 @@ namespace Chalkboard {
                         return nodeToString(mulNode);
                     }
                     case "pow": {
-                        const baseStr = (node.base.type !== "num" && node.base.type !== "var" && node.base.type !== "complex") ? `(${nodeToString(node.base)})` : nodeToString(node.base);
+                        const baseIsComplex = node.base?.type === "complex";
+                        const baseStrRaw = nodeToString(node.base);
+                        const baseStr =
+                            baseIsComplex && needsParensInPow(node.base)
+                                ? `(${baseStrRaw})`
+                                : (node.base.type !== "num" && node.base.type !== "var" && node.base.type !== "complex")
+                                    ? `(${baseStrRaw})`
+                                    : baseStrRaw;
+
                         const expStr = (node.exponent.type !== "num" && node.exponent.type !== "var" && node.exponent.type !== "complex") ? `(${nodeToString(node.exponent)})` : nodeToString(node.exponent);
                         return `${baseStr}^${expStr}`;
                     }
@@ -744,13 +751,26 @@ namespace Chalkboard {
                         return node.name;
                     }
                     case "add": {
-                        return `${nodeToLaTeX(node.left)} + ${nodeToLaTeX(node.right)}`;
+                        const right = nodeToLaTeX(node.right);
+                        if (right.startsWith("-")) return `${nodeToLaTeX(node.left)} - ${right.slice(1)}`;
+                        return `${nodeToLaTeX(node.left)} + ${right}`;
                     }
                     case "sub": {
-                        return `${nodeToLaTeX(node.left)} - ${nodeToLaTeX(node.right)}`;
+                        const right = nodeToLaTeX(node.right);
+                        if (right.startsWith("-")) return `${nodeToLaTeX(node.left)} + ${right.slice(1)}`;
+                        return `${nodeToLaTeX(node.left)} - ${right}`;
                     }
                     case "mul": {
-                        return `${nodeToLaTeX(node.left)}${nodeToLaTeX(node.right)}`;
+                        const isAtomicLaTeX = (n: any): boolean => n.type === "num" || n.type === "var" || n.type === "complex" || n.type === "pow" || n.type === "func";
+                        const wrapIfNeeded = (n: any): string => {
+                            const s = nodeToLaTeX(n);
+                            if (n.type === "add" || n.type === "sub") return `\\left(${s}\\right)`;
+                            return s;
+                        };
+                        const left = wrapIfNeeded(node.left);
+                        const right = wrapIfNeeded(node.right);
+                        if (isAtomicLaTeX(node.left) && isAtomicLaTeX(node.right)) return `${left}${right}`;
+                        return `${left} \\cdot ${right}`;
                     }
                     case "div": {
                         return `\\frac{${nodeToLaTeX(node.left)}}{${nodeToLaTeX(node.right)}}`;
@@ -775,14 +795,6 @@ namespace Chalkboard {
                 return JSON.stringify(a) === JSON.stringify(b);
             };
             const simplifyNode = (node: { type: string, [key: string]: any }): { type: string, [key: string]: any } => {
-                const isRealOnly = (node: { type: string, [key: string]: any }): boolean => {
-                    if (node.type === "complex") return node.b === 0;
-                    if (node.type === "num") return true;
-                    if (node.type === "var") return false;
-                    if (node.type === "add" || node.type === "sub" || node.type === "mul" || node.type === "div" || node.type === "pow") return isRealOnly(node.left) && isRealOnly(node.right);
-                    if (node.type === "neg") return isRealOnly(node.expr);
-                    return false;
-                };
                 switch (node.type) {
                     case "num": {
                         return { type: "complex", a: node.value, b: 0 };
@@ -819,9 +831,9 @@ namespace Chalkboard {
                                 if (node.type === "add") {
                                     return [...extractTerms(node.left), ...extractTerms(node.right)];
                                 } else if (node.type === "sub") {
-                                    const rightTerms = extractTerms(node.right).map(term => ({ 
-                                        type: "neg", 
-                                        expr: term 
+                                    const rightTerms = extractTerms(node.right).map(term => ({
+                                        type: "neg",
+                                        expr: term
                                     }));
                                     return [...extractTerms(node.left), ...rightTerms];
                                 } else {
@@ -846,10 +858,10 @@ namespace Chalkboard {
                             }
                             let result = products[0];
                             for (let i = 1; i < products.length; i++) {
-                                result = { 
-                                    type: "add", 
-                                    left: result, 
-                                    right: products[i] 
+                                result = {
+                                    type: "add",
+                                    left: result,
+                                    right: products[i]
                                 };
                             }
                             return simplifyNode(result);
@@ -881,70 +893,6 @@ namespace Chalkboard {
                     case "pow": {
                         const base = simplifyNode(node.base);
                         const exponent = simplifyNode(node.exponent);
-                        if ((base.type === "add" || base.type === "sub") && exponent.type === "complex" && exponent.b === 0 && Number.isInteger(exponent.a)) {
-                            if (exponent.a < 0) {
-                                const absExpr = Math.abs(exponent.a);
-                                if (absExpr === 1) {
-                                    return { type: "pow", base: base, exponent: { type: "complex", a: -1, b: 0 } };
-                                } else {
-                                    const positiveExpr = { type: "pow", base, exponent: { type: "complex", a: absExpr, b: 0 } };
-                                    const expanded = simplifyNode(positiveExpr);
-                                    return { type: "pow", base: expanded, exponent: { type: "complex", a: -1, b: 0 } };
-                                }
-                            } else if (exponent.a > 0) {
-                                const n = exponent.a;
-                                const a = base.left;
-                                const b = base.right;
-                                const sign = base.type === "add" ? 1 : -1;
-                                let result = null;
-                                for (let k = 0; k <= n; k++) {
-                                    const c = Chalkboard.numb.binomial(n, k);
-                                    const leftPower = n - k === 0 ? { type: "complex", a: 1, b: 0 } : (n - k === 1 ? a : simplifyNode({ type: "pow", base: a, exponent: { type: "complex", a: n - k, b: 0 } }));
-                                    const rightPower = k === 0 ? { type: "complex", a: 1, b: 0 } : (k === 1 ? (sign === 1 ? b : { type: "neg", expr: b }) : simplifyNode({ type: "pow", base: b, exponent: { type: "complex", a: k, b: 0 } }));
-                                    const termSign = (sign === -1 && k % 2 === 1) ? -1 : 1;
-                                    let term;
-                                    if (k === 0) {
-                                        term = leftPower;
-                                    } else if (n - k === 0) {
-                                        term = rightPower;
-                                    } else {
-                                        term = simplifyNode({ type: "mul", left: leftPower, right: rightPower });
-                                    }
-                                    if (c !== 1) {
-                                        term = simplifyNode({ type: "mul", left: { type: "complex", a: termSign * c, b: 0 }, right: term });
-                                    } else if (termSign === -1) {
-                                        term = { type: "neg", expr: term };
-                                    }
-                                    if (result === null) {
-                                        result = term;
-                                    } else {
-                                        result = simplifyNode({ type: "add", left: result, right: term });
-                                    }
-                                }
-                                return result;
-                            }
-                        }
-                        if (base.type === "complex" && exponent.type === "complex" && exponent.b === 0) {
-                            const power = exponent.a;
-                            if (power === 0) return { type: "complex", a: 1, b: 0 };
-                            if (power === 1) return base;
-                            if (base.a === 0 && base.b === 0 && power > 0) return { type: "complex", a: 0, b: 0 };
-                            if (base.a === 1 && base.b === 0) return { type: "complex", a: 1, b: 0 };
-                            if (base.a === 0 && base.b === 1) {
-                                const mod4 = Math.floor(power) % 4;
-                                if (mod4 === 0) return { type: "complex", a: 1, b: 0 };
-                                if (mod4 === 1) return { type: "complex", a: 0, b: 1 };
-                                if (mod4 === 2) return { type: "complex", a: -1, b: 0 };
-                                if (mod4 === 3) return { type: "complex", a: 0, b: -1 };
-                            }
-                            if (Number.isInteger(power) && power > 1 && power <= 3) {
-                                let result = base;
-                                for (let i = 1; i < power; i++) {
-                                    result = { type: "complex", a: result.a * base.a - result.b * base.b, b: result.a * base.b + result.b * base.a };
-                                }
-                                return result;
-                            }
-                        }
                         return { type: "pow", base, exponent };
                     }
                     case "neg": {
@@ -955,53 +903,177 @@ namespace Chalkboard {
                     }
                     case "func": {
                         const args = node.args.map((arg: { type: string, [key: string]: any }) => simplifyNode(arg));
-                        const funcName = node.name.toLowerCase();
-                        if (args.every((arg: { type: string, [key: string]: any }) => arg.type === "complex")) {
-                            try {
-                                switch (funcName) {
-                                    case "conj":
-                                    case "conjugate":
-                                        return { type: "complex", a: args[0].a, b: -args[0].b };
-                                    case "mag":
-                                        return { type: "complex", a: Math.sqrt(args[0].a * args[0].a + args[0].b * args[0].b), b: 0 };
-                                    case "magsq":
-                                        return { type: "complex", a: args[0].a * args[0].a + args[0].b * args[0].b, b: 0 };
-                                    case "arg":
-                                        return { type: "complex", a: Math.atan2(args[0].b, args[0].a), b: 0 };
-                                    case "re":
-                                        return { type: "complex", a: args[0].a, b: 0 };
-                                    case "im":
-                                        return { type: "complex", a: args[0].b, b: 0 };
-                                    case "sqrt":
-                                        if (args[0].b === 0 && args[0].a >= 0) {
-                                            const z = Chalkboard.comp.sqrt(Chalkboard.comp.init(args[0].a, args[0].b)) as ChalkboardComplex;
-                                            return { type: "complex", a: z.a, b: z.b };
-                                        }
-                                        break;
-                                    case "sq":
-                                        const z = Chalkboard.comp.sq(Chalkboard.comp.init(args[0].a, args[0].b)) as ChalkboardComplex;
-                                        return { type: "complex", a: z.a, b: z.b };
-                                }
-                            } catch (e) {}
-                        }
-                        if (args.every((arg: { type: string, [key: string]: any }) => arg.type === "complex" && arg.b === 0)) {
-                            try {
-                                switch (funcName) {
-                                    case "sin":
-                                    case "cos":
-                                    case "tan":
-                                    case "log":
-                                    case "ln":
-                                    case "exp":
-                                    case "abs":
-                                        break;
-                                }
-                            } catch (e) {}
-                        }
                         return { type: "func", name: node.name, args };
                     }
                 }
                 return node;
+            };
+            const isRealOnly = (node: { type: string, [key: string]: any }): boolean => {
+                switch (node.type) {
+                    case "num": return true;
+                    case "var": return true;
+                    case "complex": return node.b === 0;
+                    case "neg": return isRealOnly(node.expr);
+                    case "add":
+                    case "sub":
+                    case "mul":
+                    case "div": return isRealOnly(node.left) && isRealOnly(node.right);
+                    case "pow": return isRealOnly(node.base) && isRealOnly(node.exponent);
+                    case "func": return node.args.every(isRealOnly);
+                    default: return false;
+                }
+            };
+            const realNum = (n: number): any => ({ type: "num", value: n });
+            const realAdd = (l: any, r: any): any => ({ type: "add", left: l, right: r });
+            const realSub = (l: any, r: any): any => ({ type: "sub", left: l, right: r });
+            const realMul = (l: any, r: any): any => ({ type: "mul", left: l, right: r });
+            const realDiv = (l: any, r: any): any => ({ type: "div", left: l, right: r });
+            const realPow = (b: any, e: any): any => ({ type: "pow", base: b, exponent: e });
+            const realNeg = (x: any): any => ({ type: "neg", expr: x });
+            const realNodeToString = (node: any): string => {
+                switch (node.type) {
+                    case "num": return node.value.toString();
+                    case "var": return node.name;
+                    case "add": return `${realNodeToString(node.left)} + ${realNodeToString(node.right)}`;
+                    case "sub": return `${realNodeToString(node.left)} - ${realNodeToString(node.right)}`;
+                    case "mul": {
+                        const L = (node.left.type === "add" || node.left.type === "sub") ? `(${realNodeToString(node.left)})` : realNodeToString(node.left);
+                        const R = (node.right.type === "add" || node.right.type === "sub") ? `(${realNodeToString(node.right)})` : realNodeToString(node.right);
+                        return `${L} * ${R}`;
+                    }
+                    case "div": {
+                        const L = (node.left.type === "add" || node.left.type === "sub") ? `(${realNodeToString(node.left)})` : realNodeToString(node.left);
+                        const R = (node.right.type === "add" || node.right.type === "sub") ? `(${realNodeToString(node.right)})` : realNodeToString(node.right);
+                        return `${L} / ${R}`;
+                    }
+                    case "pow": {
+                        const B = (node.base.type === "num" || node.base.type === "var") ? realNodeToString(node.base) : `(${realNodeToString(node.base)})`;
+                        const E = (node.exponent.type === "num" || node.exponent.type === "var") ? realNodeToString(node.exponent) : `(${realNodeToString(node.exponent)})`;
+                        return `${B}^${E}`;
+                    }
+                    case "neg": {
+                        const inner = (node.expr.type === "num" || node.expr.type === "var") ? realNodeToString(node.expr) : `(${realNodeToString(node.expr)})`;
+                        return `-${inner}`;
+                    }
+                    default: {
+                        throw new Error(`Chalkboard.comp.parse: Unsupported real-node type ${node.type}`);
+                    }
+                }
+            };
+            const simplifyRealString = (s: string): string => {
+                return Chalkboard.real.parse(s, {
+                    roundTo: config.roundTo,
+                    returnAST: false,
+                    returnJSON: false,
+                    returnLaTeX: false
+                }) as string;
+            };
+            const toReIm = (node: any): { re: any, im: any } => {
+                switch (node.type) {
+                    case "num": {
+                        return { re: realNum(node.value), im: realNum(0) };
+                    }
+                    case "var": {
+                        if (node.name === "i") return { re: realNum(0), im: realNum(1) };
+                        return { re: { type: "var", name: node.name }, im: realNum(0) };
+                    }
+                    case "complex": {
+                        return { re: realNum(node.a), im: realNum(node.b) };
+                    }
+                    case "neg": {
+                        const p = toReIm(node.expr);
+                        return { re: realNeg(p.re), im: realNeg(p.im) };
+                    }
+                    case "add": {
+                        const L = toReIm(node.left);
+                        const R = toReIm(node.right);
+                        return { re: realAdd(L.re, R.re), im: realAdd(L.im, R.im) };
+                    }
+                    case "sub": {
+                        const L = toReIm(node.left);
+                        const R = toReIm(node.right);
+                        return { re: realSub(L.re, R.re), im: realSub(L.im, R.im) };
+                    }
+                    case "mul": {
+                        const L = toReIm(node.left);
+                        const R = toReIm(node.right);
+                        const ac = realMul(L.re, R.re);
+                        const bd = realMul(L.im, R.im);
+                        const ad = realMul(L.re, R.im);
+                        const bc = realMul(L.im, R.re);
+                        return { re: realSub(ac, bd), im: realAdd(ad, bc) };
+                    }
+                    case "div": {
+                        const L = toReIm(node.left);
+                        const R = toReIm(node.right);
+                        const c2 = realPow(R.re, realNum(2));
+                        const d2 = realPow(R.im, realNum(2));
+                        const denom = realAdd(c2, d2);
+                        const ac = realMul(L.re, R.re);
+                        const bd = realMul(L.im, R.im);
+                        const bc = realMul(L.im, R.re);
+                        const ad = realMul(L.re, R.im);
+                        const reNum = realAdd(ac, bd);
+                        const imNum = realSub(bc, ad);
+                        return { re: realDiv(reNum, denom), im: realDiv(imNum, denom) };
+                    }
+                    case "pow": {
+                        const expParts = toReIm(node.exponent);
+                        const expImStr = simplifyRealString(realNodeToString(expParts.im));
+                        if (expImStr !== "0") throw new Error("Chalkboard.comp.parse: Complex exponent not supported in symbolic splitting.");
+                        const expReStr = simplifyRealString(realNodeToString(expParts.re));
+                        const n = Number(expReStr);
+                        if (!Number.isInteger(n)) throw new Error("Chalkboard.comp.parse: Non-integer exponent not supported in symbolic splitting.");
+                        const baseParts = toReIm(node.base);
+                        let re = realNum(1);
+                        let im = realNum(0);
+                        const steps = Math.abs(n);
+                        for (let i = 0; i < steps; i++) {
+                            const a = re;
+                            const b = im;
+                            const c = baseParts.re;
+                            const d = baseParts.im;
+                            const newRe = realSub(realMul(a, c), realMul(b, d));
+                            const newIm = realAdd(realMul(a, d), realMul(b, c));
+                            re = newRe;
+                            im = newIm;
+                        }
+                        if (n < 0) {
+                            const denom = realAdd(realPow(re, realNum(2)), realPow(im, realNum(2)));
+                            const reInv = realDiv(re, denom);
+                            const imInv = realNeg(realDiv(im, denom));
+                            return { re: reInv, im: imInv };
+                        }
+                        return { re, im };
+                    }
+                    case "func": {
+                        throw new Error(`Chalkboard.comp.parse: Symbolic splitting for function '${node.name}' not supported.`);
+                    }
+                }
+                throw new Error(`Chalkboard.comp.parse: Unsupported node type '${node.type}' in symbolic splitting.`);
+            };
+            const combineReImStrings = (reStr: string, imStr: string): string => {
+                const reS = reStr.trim();
+                const imS = imStr.trim();
+                const isZero = (s: string): boolean => s === "0" || s === "0.0";
+                const needsParens = (s: string): boolean => {
+                    return s.includes(" + ") || s.includes(" - ");
+                };
+                if (isZero(imS)) return reS;
+                if (isZero(reS)) {
+                    if (imS === "1") return "i";
+                    if (imS === "-1") return "-i";
+                    return needsParens(imS) ? `(${imS})i` : `${imS}i`;
+                }
+                const imWithI = imS === "1" ? "i" : imS === "-1" ? "-i" : needsParens(imS) ? `(${imS})i` : `${imS}i`;
+                if (!needsParens(imS) && imS.startsWith("-")) {
+                    const mag = imS.slice(1);
+                    if (mag === "1") return `${reS} - i`;
+                    return `${reS} - ${mag}i`;
+                } else {
+                    if (imWithI.startsWith("-")) return `${reS} - ${imWithI.slice(1)}`;
+                    return `${reS} + ${imWithI}`;
+                }
             };
             try {
                 const tokens = tokenize(expr);
@@ -1009,13 +1081,44 @@ namespace Chalkboard {
                 if (config.values && Object.keys(config.values).length > 0) {
                     const result = evaluateNode(ast, config.values);
                     if (config.roundTo !== undefined) {
-                        return Chalkboard.comp.init(Chalkboard.numb.roundTo(result.a, config.roundTo), Chalkboard.numb.roundTo(result.b, config.roundTo));
+                        return Chalkboard.comp.init(
+                            Chalkboard.numb.roundTo(result.a, config.roundTo),
+                            Chalkboard.numb.roundTo(result.b, config.roundTo)
+                        );
                     }
                     return result;
                 }
+                if (isRealOnly(ast)) {
+                    return Chalkboard.real.parse(expr, {
+                        roundTo: config.roundTo,
+                        returnAST: config.returnAST,
+                        returnJSON: config.returnJSON,
+                        returnLaTeX: config.returnLaTeX
+                    }) as any;
+                }
+                if (!config.returnAST && !config.returnJSON) {
+                    try {
+                        const parts = toReIm(ast);
+                        const reExprStr = realNodeToString(parts.re);
+                        const imExprStr = realNodeToString(parts.im);
+                        if (reExprStr.includes("i") || imExprStr.includes("i")) {
+                            throw new Error("Chalkboard.comp.parse: Internal error: 'i' leaked into real split.");
+                        }
+                        const reSimpl = simplifyRealString(reExprStr);
+                        const imSimpl = simplifyRealString(imExprStr);
+                        if (config.returnLaTeX) {
+                            const reTex = Chalkboard.real.parse(reExprStr, { returnLaTeX: true, roundTo: config.roundTo }) as string;
+                            const imTex = Chalkboard.real.parse(imExprStr, { returnLaTeX: true, roundTo: config.roundTo }) as string;
+                            if (imTex.trim() === "0") return reTex;
+                            if (reTex.trim() === "0") return `${imTex}i`;
+                            return `${reTex} + ${String.raw`\left(${imTex}\right)`}i`;
+                        }
+                        return combineReImStrings(reSimpl, imSimpl);
+                    } catch (e) {
+
+                    }
+                }
                 let simplified = simplifyNode(ast);
-                let normalizedast = parseTokens(tokenize(nodeToString(simplified)));
-                simplified = simplifyNode(normalizedast);
                 simplified = simplifyNode(simplified);
                 if (config.roundTo !== undefined) {
                     const roundNodes = (node: { type: string, [key: string]: any }): { type: string, [key: string]: any } => {
@@ -1032,7 +1135,9 @@ namespace Chalkboard {
                 }
                 if (config.returnAST) return simplified;
                 if (config.returnJSON) return JSON.stringify(simplified);
-                if (config.returnLaTeX) return nodeToLaTeX(simplified);
+                if (config.returnLaTeX) {
+                    return nodeToLaTeX(simplified);
+                }
                 return nodeToString(simplified);
             } catch (err) {
                 if (err instanceof Error) {

--- a/src/Chalkboard-diff.ts
+++ b/src/Chalkboard-diff.ts
@@ -10,6 +10,179 @@ namespace Chalkboard {
      */
     export namespace diff {
         /**
+         * Samples the solution at a time using linear interpolation between the nearest grid points. (No extrapolation as it clamps to endpoints.)
+         * @param {{ t: number[]; y: number[][] }} sol - The solution.
+         * @param {number} time - The time to sample at.
+         * @returns {number[]}
+         */
+        export const at = (sol: { t: number[]; y: number[][] }, time: number): number[] => {
+            ASSERT(typeof time === "number" && Number.isFinite(time), `Chalkboard.diff.at: Parameter "time" must be a finite number.`);
+            const t = sol.t;
+            const y = sol.y;
+            ASSERT(t.length === y.length && t.length > 0, `Chalkboard.diff.at: Invalid solution object.`);
+            if (time <= t[0]) return y[0].slice();
+            if (time >= t[t.length - 1]) return y[y.length - 1].slice();
+            let i = 0;
+            while (i < t.length - 1 && !(t[i] <= time && time <= t[i + 1])) i++;
+            const t0 = t[i], t1 = t[i + 1];
+            const a = (time - t0) / (t1 - t0);
+            const result: number[] = [];
+            for (let k = 0; k < y[i].length; k++) result.push((1 - a) * y[i][k] + a * y[i + 1][k]);
+            return result;
+        };
+
+        /**
+         * Defines a Bernoulli equation: y' + p(t)y = q(t)y^n. Equivalent: y' = -p(t)y + q(t)y^n.
+         * @param {number | ((t: number) => number)} p - p or p(t)
+         * @param {number | ((t: number) => number)} q - q or q(t)
+         * @param {number} n - Exponent
+         * @returns {ChalkboardODE}
+         */
+        export const Bernoulli = (p: number | ((t: number) => number), q: number | ((t: number) => number), n: number): ChalkboardODE => {
+            ASSERT(typeof n === "number" && Number.isFinite(n), `Chalkboard.diff.Bernoulli: Parameter "n" must be a finite number.`);
+            const P = (typeof p === "number") ? ((t: number) => p) : p;
+            const Q = (typeof q === "number") ? ((t: number) => q) : q;
+            return Chalkboard.diff.init((t: number, y: number) => -P(t) * y + Q(t) * Math.pow(y, n));
+        };
+
+        /**
+         * Returns the index of the time grid closest to a target time.
+         * @param {number[]} t - Time array.
+         * @param {number} target - Target time.
+         * @returns {number}
+         */
+        export const closestIndex = (t: number[], target: number): number => {
+            ASSERT(Array.isArray(t) && t.length > 0, `Chalkboard.diff.closestIndex: Parameter "t" must be a non-empty array.`);
+            ASSERT(typeof target === "number" && Number.isFinite(target), `Chalkboard.diff.closestIndex: Parameter "target" must be a finite number.`);
+            let result = 0;
+            let resultDist = Math.abs(t[0] - target);
+            for (let i = 1; i < t.length; i++) {
+                const d = Math.abs(t[i] - target);
+                if (d < resultDist) {
+                    resultDist = d;
+                    result = i;
+                }
+            }
+            return result;
+        };
+
+        /**
+         * Returns a single component series from the solution of an ODE.
+         * @param {{ t: number[]; y: number[][] }} sol - The solution of the ODE.
+         * @param {number} index - Component index.
+         * @returns {number[]}
+         */
+        export const component = (sol: { t: number[]; y: number[][] }, index: number): number[] => {
+            ASSERT(Number.isInteger(index) && index >= 0, `Chalkboard.diff.component: Parameter "index" must be an integer >= 0.`);
+            const result: number[] = [];
+            for (let i = 0; i < sol.y.length; i++) {
+                ASSERT(index < sol.y[i].length, `Chalkboard.diff.component: "index" out of range for solution dimension.`);
+                result.push(sol.y[i][index]);
+            }
+            return result;
+        };
+
+        /**
+         * Returns an estimate of y'(t) (an estimate of the derivative series) from a solved solution using finite differences on the solution grid.
+         * @param {{ t: number[]; y: number[][] }} sol - Solution
+         * @returns {number[][]}
+         */
+        export const derivative = (sol: { t: number[]; y: number[][] }): number[][] => {
+            ASSERT(sol && Array.isArray(sol.t) && Array.isArray(sol.y), `Chalkboard.diff.derivative: Invalid solution object.`);
+            const t = sol.t;
+            const y = sol.y;
+            ASSERT(t.length === y.length && t.length >= 2, `Chalkboard.diff.derivative: Need at least 2 samples.`);
+            const n = y[0].length;
+            const dy: number[][] = new Array(y.length);
+            for (let i = 0; i < y.length; i++) dy[i] = new Array(n).fill(0);
+            for (let i = 0; i < y.length; i++) {
+                if (i === 0) {
+                    const dt = t[1] - t[0];
+                    for (let k = 0; k < n; k++) dy[i][k] = (y[1][k] - y[0][k]) / dt;
+                } else if (i === y.length - 1) {
+                    const dt = t[t.length - 1] - t[t.length - 2];
+                    for (let k = 0; k < n; k++) dy[i][k] = (y[y.length - 1][k] - y[y.length - 2][k]) / dt;
+                } else {
+                    const dt = t[i + 1] - t[i - 1];
+                    for (let k = 0; k < n; k++) dy[i][k] = (y[i + 1][k] - y[i - 1][k]) / dt;
+                }
+            }
+            return dy;
+        };
+
+        /**
+         * Defines a Duffing equation: x'' + δx' + αx + βx^3 = γcos(ωt). Equivalent: x'' = -δx' - αx - βx^3 + γcos(ωt).
+         * @param {number} delta - δ
+         * @param {number} alpha - α
+         * @param {number} beta - β
+         * @param {number} gamma - γ
+         * @param {number} omega - ω
+         * @returns {ChalkboardODE}
+         */
+        export const Duffing = (delta: number, alpha: number, beta: number, gamma: number, omega: number): ChalkboardODE => {
+            ASSERT([delta, alpha, beta, gamma, omega].every((n) => typeof n === "number" && Number.isFinite(n)), `Chalkboard.diff.Duffing: Parameters must be finite numbers.`);
+            return Chalkboard.diff.init((t: number, x: number, v: number) => -delta * v - alpha * x - beta * x * x * x + gamma * Math.cos(omega * t));
+        };
+
+        /**
+         * Defines an exponential growth/decay equation: y' = ky
+         * @param {number} k - Rate
+         * @returns {ChalkboardODE}
+         */
+        export const exponential = (k: number = 1): ChalkboardODE => {
+            ASSERT(typeof k === "number" && Number.isFinite(k), `Chalkboard.diff.exponential: Parameter "k" must be a finite number.`);
+            return Chalkboard.diff.init((t: number, y: number) => k * y);
+        };
+
+        /**
+         * Defines a Gompertz equation: y' = ayln(K/y).
+         * @param {number} a - Growth rate
+         * @param {number} K - Carrying capacity (K > 0)
+         * @returns {ChalkboardODE}
+         */
+        export const Gompertz = (a: number = 1, K: number = 1): ChalkboardODE => {
+            ASSERT(typeof a === "number" && Number.isFinite(a), `Chalkboard.diff.Gompertz: Parameter "a" must be a finite number.`);
+            ASSERT(typeof K === "number" && Number.isFinite(K) && K > 0, `Chalkboard.diff.Gompertz: Parameter "K" must be greater than 0.`);
+            return Chalkboard.diff.init((t: number, y: number) => a * y * Math.log(K / y));
+        };
+
+        /**
+         * Defines an undamped harmonic oscillator: y'' + (w^2)y = 0. Equivalent: y'' = -(w^2)y.
+         * @param {number} w - Angular frequency (must be greater than or equal to 0)
+         * @returns {ChalkboardODE}
+         */
+        export const harmonic = (w: number = 1): ChalkboardODE => {
+            ASSERT(typeof w === "number" && Number.isFinite(w) && w >= 0, `Chalkboard.diff.harmonic: Parameter "w" must be a finite number greater than or equal to 0.`);
+            return Chalkboard.diff.init((t: number, y: number, dy: number) => -(w * w) * y);
+        };
+
+        /**
+         * Defines a damped harmonic oscillator: y'' + (2ζω)y' + (ω^2)y = 0. Equivalent: y'' = -(2ζω)y' - (ω^2)y.
+         * @param {number} w - Angular frequency (must be greater than or equal to 0)
+         * @param {number} zeta - Damping ratio (must be greater than or equal to 0)
+         * @returns {ChalkboardODE}
+         */
+        export const harmonicDamped = (w: number = 1, zeta: number = 0.1): ChalkboardODE => {
+            ASSERT(typeof w === "number" && Number.isFinite(w) && w >= 0, `Chalkboard.diff.harmonicDamped: Parameter "w" must be a finite number greater than or equal to 0.`);
+            ASSERT(typeof zeta === "number" && Number.isFinite(zeta) && zeta >= 0, `Chalkboard.diff.harmonicDamped: Parameter "zeta" must be a finite number greater than or equal to 0.`);
+            return Chalkboard.diff.init((t: number, y: number, dy: number) => -2 * zeta * w * dy - (w * w) * y);
+        };
+
+        /**
+         * Defines a forced harmonic oscillator: y'' + (2ζω)y' + (ω^2)y = F(t). Equivalent: y'' = F(t) - (2ζω)y' - (ω^2)y.
+         * @param {number} w - Angular frequency (must be greater than or equal to 0)
+         * @param {number} zeta - Damping ratio (must be greater than or equal to 0)
+         * @param {(t: number) => number} F - Forcing term
+         * @returns {ChalkboardODE}
+         */
+        export const harmonicForced = (w: number, zeta: number, F: (t: number) => number): ChalkboardODE => {
+            ASSERT(typeof w === "number" && Number.isFinite(w) && w >= 0, `Chalkboard.diff.harmonicForced: Parameter "w" must be a finite number greater than or equal to 0.`);
+            ASSERT(typeof zeta === "number" && Number.isFinite(zeta) && zeta >= 0, `Chalkboard.diff.harmonicForced: Parameter "zeta" must be a finite number greater than or equal to 0.`);
+            ASSERT(typeof F === "function", `Chalkboard.diff.harmonicForced: Parameter "F" must be a function.`);
+            return Chalkboard.diff.init((t: number, y: number, dy: number) => F(t) - 2 * zeta * w * dy - (w * w) * y);
+        };
+
+        /**
          * Defines an ordinary differential equation.
          * @param {((t: number, y: number) => number) | ((t: number, y: number, dy: number) => number) | ((t: number, y: number[]) => number[])} rule - The differential equation rule function.
          * @param {number} [dimension] - Optional, the dimension of the system only required for system equations.
@@ -78,6 +251,99 @@ namespace Chalkboard {
                 };
             }
             throw new Error(`Chalkboard.diff.init: Invalid "rule" arity. Expected (t,y) or (t,y,dy), or provide dimension for systems.`);
+        };
+
+        /**
+         * Defines a first-order linear scalar ODE: y' = a(t)y + b(t).
+         * @param {((t: number) => number) | number} a - Coefficient a(t) or constant a.
+         * @param {((t: number) => number) | number} b - Coefficient b(t) or constant b.
+         * @returns {ChalkboardODE}
+         */
+        export const linear1 = (a: ((t: number) => number) | number, b: ((t: number) => number) | number): ChalkboardODE => {
+            const A = typeof a === "number" ? (() => a) : a;
+            const B = typeof b === "number" ? (() => b) : b;
+            return Chalkboard.diff.init((t: number, y: number) => A(t) * y + B(t));
+        };
+
+        /**
+         * Defines a second-order linear scalar ODE: y'' = a(t)y' + b(t)y + c(t).
+         * @param {((t: number) => number) | number} a - Coefficient a(t) or constant a.
+         * @param {((t: number) => number) | number} b - Coefficient b(t) or constant b.
+         * @param {((t: number) => number) | number} c - Coefficient c(t) or constant c.
+         * @returns {ChalkboardODE}
+         */
+        export const linear2 = (a: ((t: number) => number) | number, b: ((t: number) => number) | number, c: ((t: number) => number) | number): ChalkboardODE => {
+            const A = typeof a === "number" ? (() => a) : a;
+            const B = typeof b === "number" ? (() => b) : b;
+            const C = typeof c === "number" ? (() => c) : c;
+            return Chalkboard.diff.init((t: number, y: number, dy: number) => A(t) * dy + B(t) * y + C(t));
+        };
+
+        /**
+         * Defines a logistic growth model: y' = ry(1 - y/K).
+         * @param {number} r - Growth rate
+         * @param {number} K - Carrying capacity (non-zero)
+         * @returns {ChalkboardODE}
+         */
+        export const logistic = (r: number = 1, K: number = 1): ChalkboardODE => {
+            ASSERT(typeof r === "number" && Number.isFinite(r), `Chalkboard.diff.logistic: Parameter "r" must be a finite number.`);
+            ASSERT(typeof K === "number" && Number.isFinite(K) && K !== 0, `Chalkboard.diff.logistic: Parameter "K" must be a finite non-zero number.`);
+            return Chalkboard.diff.init((t: number, y: number) => r * y * (1 - y / K));
+        };
+
+        /**
+         * Defines a Lotka–Volterra predator-prey model: x' = αx - βxy, y' = δxy - γy.
+         * @param {number} alpha - Prey growth rate
+         * @param {number} beta - Predation rate
+         * @param {number} gamma - Predator death rate
+         * @param {number} delta - Predator reproduction rate
+         * @returns {ChalkboardODE}
+         */
+        export const LotkaVolterra = (alpha: number = 1, beta: number = 1, gamma: number = 1, delta: number = 1): ChalkboardODE => {
+            ASSERT([alpha, beta, gamma, delta].every((n) => typeof n === "number" && Number.isFinite(n)), `Chalkboard.diff.LotkaVolterra: Parameters must be finite numbers.`);
+            return Chalkboard.diff.init((t: number, y: number[]) => {
+                const x = y[0], p = y[1];
+                return [alpha * x - beta * x * p, delta * x * p - gamma * p];
+            }, 2);
+        };
+
+        /**
+         * Defines a mass-spring-damper system: mx'' + cx' + kx = 0. Equivalent: x'' = -(c/m)x' - (k/m)x.
+         * @param {number} m - Mass (non-zero)
+         * @param {number} c - Damping
+         * @param {number} k - Spring constant
+         * @returns {ChalkboardODE}
+         */
+        export const massSpringDamper = (m: number, c: number, k: number): ChalkboardODE => {
+            ASSERT(typeof m === "number" && Number.isFinite(m) && m !== 0, `Chalkboard.diff.massSpringDamper: Parameter "m" must be finite and non-zero.`);
+            ASSERT(typeof c === "number" && Number.isFinite(c), `Chalkboard.diff.massSpringDamper: Parameter "c" must be a finite number.`);
+            ASSERT(typeof k === "number" && Number.isFinite(k), `Chalkboard.diff.massSpringDamper: Parameter "k" must be a finite number.`);
+            return Chalkboard.diff.init((t: number, x: number, v: number) => -(c / m) * v - (k / m) * x);
+        };
+
+        /**
+         * Defines a separable ODE: y' = f(t)g(y)
+         * @param {(t: number) => number} f - f(t)
+         * @param {(y: number) => number} g - g(y)
+         * @returns {ChalkboardODE}
+         */
+        export const separable = (f: (t: number) => number, g: (y: number) => number): ChalkboardODE => {
+            ASSERT(typeof f === "function" && typeof g === "function", `Chalkboard.diff.separable: Parameters must be functions.`);
+            return Chalkboard.diff.init((t: number, y: number) => f(t) * g(y));
+        };
+
+        /**
+         * Defines an SIR epidemic model: S' = -βSI, I' = βSI - γI, R' = γI.
+         * @param {number} beta - Infection rate
+         * @param {number} gamma - Recovery rate
+         * @returns {ChalkboardODE}
+         */
+        export const SIR = (beta: number = 1, gamma: number = 1): ChalkboardODE => {
+            ASSERT([beta, gamma].every((n) => typeof n === "number" && Number.isFinite(n)), `Chalkboard.diff.SIR: Parameters must be finite numbers.`);
+            return Chalkboard.diff.init((t: number, y: number[]) => {
+                const S = y[0], I = y[1], R = y[2];
+                return [-beta * S * I, beta * S * I - gamma * I, gamma * I];
+            }, 3);
         };
 
         /**
@@ -270,6 +536,17 @@ namespace Chalkboard {
                     return obj;
                 });
             }
+            return result;
+        };
+
+        /**
+         * Returns the first component of a solution of an ODE.
+         * @param {{ t: number[]; y: number[][] }} sol - The solution of the ODE.
+         * @returns {number[]}
+         */
+        export const toScalarSeries = (sol: { t: number[]; y: number[][] }): number[] => {
+            const result: number[] = [];
+            for (let i = 0; i < sol.y.length; i++) result.push(sol.y[i][0]);
             return result;
         };
     }

--- a/src/Chalkboard-diff.ts
+++ b/src/Chalkboard-diff.ts
@@ -1,0 +1,276 @@
+/*
+    The Chalkboard Library - Differential Equations Namespace
+    Version 2.4.0 Noether
+*/
+/// <reference path="Chalkboard.ts"/>
+namespace Chalkboard {
+    /**
+     * The differential equations namespace.
+     * @namespace
+     */
+    export namespace diff {
+        /**
+         * Defines an ordinary differential equation.
+         * @param {((t: number, y: number) => number) | ((t: number, y: number, dy: number) => number) | ((t: number, y: number[]) => number[])} rule - The differential equation rule function.
+         * @param {number} [dimension] - Optional, the dimension of the system only required for system equations.
+         * @returns {ChalkboardODE}
+         * @example
+         * // First-order scalar ODE: y' = -2y
+         * const ode1 = Chalkboard.diff.init((t, y) => -2 * y);
+         * 
+         * // Second-order scalar ODE: y'' = -y  (harmonic oscillator)
+         * const ode2 = Chalkboard.diff.init((t, y, dy) => -y);
+         * 
+         * // System ODE: dy/dt = [y2, -y1]  (2D system)
+         * const odeSys = Chalkboard.diff.init((t, y) => [y[1], -y[0]], 2);
+         */
+        export const init = (
+            rule: ((t: number, y: number) => number) | ((t: number, y: number, dy: number) => number) | ((t: number, y: number[]) => number[]),
+            dimension?: number
+        ): ChalkboardODE => {
+            ASSERT(typeof rule === "function", `Chalkboard.diff.init: Parameter "rule" must be a function.`);
+            if (typeof dimension === "number") {
+                ASSERT(Number.isInteger(dimension) && dimension >= 1, `Chalkboard.diff.init: Parameter "dimension" must be an integer >= 1.`);
+                const sys = rule as (t: number, y: number[]) => number[];
+                const ode: ChalkboardODE = {
+                    rule: (t: number, y: number[]) => {
+                        const out = sys(t, y);
+                        ASSERT(Array.isArray(out), `Chalkboard.diff: System rule must return a number[].`);
+                        ASSERT(out.length === dimension, `Chalkboard.diff: System rule must return an array of length ${dimension}.`);
+                        for (let i = 0; i < out.length; i++) {
+                            ASSERT(typeof out[i] === "number" && Number.isFinite(out[i]), `Chalkboard.diff: System rule output must be finite numbers (index ${i}).`);
+                        }
+                        return out;
+                    },
+                    type: "system",
+                    order: 1,
+                    dimension
+                };
+                return ode;
+            }
+            const arity = (rule as Function).length;
+            if (arity === 2) {
+                const f = rule as (t: number, y: number) => number;
+                return {
+                    rule: (t: number, y: number[]) => {
+                        ASSERT(y.length === 1, `Chalkboard.diff: Internal error (expected dimension 1).`);
+                        const dy = f(t, y[0]);
+                        ASSERT(typeof dy === "number" && Number.isFinite(dy), `Chalkboard.diff: Scalar rule must return a finite number.`);
+                        return [dy];
+                    },
+                    type: "single",
+                    order: 1,
+                    dimension: 1
+                };
+            }
+            if (arity === 3) {
+                const g = rule as (t: number, y: number, dy: number) => number;
+                return {
+                    rule: (t: number, y: number[]) => {
+                        ASSERT(y.length === 2, `Chalkboard.diff: Internal error (expected dimension 2 for second-order scalar).`);
+                        const ddy = g(t, y[0], y[1]);
+                        ASSERT(typeof ddy === "number" && Number.isFinite(ddy), `Chalkboard.diff: Second-order scalar rule must return a finite number.`);
+                        return [y[1], ddy];
+                    },
+                    type: "single",
+                    order: 2,
+                    dimension: 2
+                };
+            }
+            throw new Error(`Chalkboard.diff.init: Invalid "rule" arity. Expected (t,y) or (t,y,dy), or provide dimension for systems.`);
+        };
+
+        /**
+         * Solves an ordinary differential equation using an explicit method.
+         * @param {ChalkboardODE} ode - The ordinary differential equation to solve.
+         * @param {Object} config - The solver configuration object.
+         * @param {number} [config.t0=0] - The initial time.
+         * @param {number} config.t1 - The final time.
+         * @param {number} [config.h] - The time step size. Either this or `steps` must be provided.
+         * @param {number} [config.steps] - The number of steps to take. Either this or `h` must be provided.
+         * @param {number | number[] | Object} config.y0 - The initial state.
+         * @param {"euler" | "midpoint" | "heun" | "ralston" | "rk4"} [config.method="rk4"] - The integration method to use: "euler", "midpoint", "heun", "ralston", or "rk4".
+         * @param {boolean} [config.returnObject=false] - Whether to return the results as an array of objects (only if initial state was provided as an object).
+         * @returns {{ t: number[]; y: number[][]; yObj?: {[key: string]: number}[]; }} The solution containing time points `t`, state array `y`, and optionally state objects `yObj`.
+         * @example
+         * // Solve first-order ODE using Euler's method:
+         * const ode1 = Chalkboard.diff.init((t, y) => -2 * y);
+         * const sol1 = Chalkboard.diff.solve(ode1, {
+         *     t0: 0, t1: 5, h: 0.1,
+         *     y0: 1,
+         *     method: "euler"
+         * });
+         * 
+         * // Solve second-order ODE using Ralston method:
+         * const ode2 = Chalkboard.diff.init((t, y, dy) => -y);
+         * const sol2 = Chalkboard.diff.solve(ode2, {
+         *     t0: 0, t1: 10, steps: 100,
+         *     y0: { y0: 1, dy0: 0 },
+         *     method: "ralston",
+         *     returnObject: true
+         * });
+         * 
+         * // Solve system ODE using fourth-order Runge-Kutta method:
+         * const odeSys = Chalkboard.diff.init((t, y) => [y[1], -y[0]], 2);
+         * const solSys = Chalkboard.diff.solve(odeSys, {
+         *     t0: 0, t1: 10, steps: 100,
+         *     y0: [1, 0]
+         * });
+         */
+        export const solve = (
+            ode: ChalkboardODE,
+            config: {
+                t0?: number;
+                t1: number;
+                h?: number;
+                steps?: number;
+                y0: number | number[] | Record<string, any>;
+                method?: "euler" | "midpoint" | "heun" | "ralston" | "rk4";
+                returnObject?: boolean;
+            }
+        ): { t: number[]; y: number[][]; yObj?: {[key: string]: number}[]; } => {
+            ASSERT(ode && typeof ode === "object", `Chalkboard.diff.solve: Parameter "ode" must be a ChalkboardODE.`);
+            ASSERT(typeof ode.rule === "function", `Chalkboard.diff.solve: "ode.rule" must be a function.`);
+            ASSERT(Number.isInteger(ode.dimension) && ode.dimension >= 1, `Chalkboard.diff.solve: "ode.dimension" must be an integer >= 1.`);
+            ASSERT(typeof config === "object" && config !== null, `Chalkboard.diff.solve: Parameter "config" must be an object.`);
+            ASSERT(typeof config.t1 === "number" && Number.isFinite(config.t1), `Chalkboard.diff.solve: "config.t1" must be a finite number.`);
+            const t0 = config.t0 ?? 0;
+            ASSERT(typeof t0 === "number" && Number.isFinite(t0), `Chalkboard.diff.solve: "config.t0" must be a finite number.`);
+            ASSERT(config.t1 !== t0, `Chalkboard.diff.solve: "config.t1" must be different from "config.t0".`);
+            const method: "euler" | "midpoint" | "heun" | "ralston" | "rk4" = (config.method ?? "rk4").toLowerCase() as "euler" | "midpoint" | "heun" | "ralston" | "rk4";
+            ASSERT(["euler", "midpoint", "heun", "ralston", "rk4"].indexOf(method) !== -1, `Chalkboard.diff.solve: Unknown method.`);
+            let y0: number[];
+            let keys: string[] | undefined;
+            if (typeof config.y0 === "number" && Number.isFinite(config.y0)) {
+                ASSERT(ode.dimension === 1, `Chalkboard.diff.solve: Scalar "y0" is only allowed when "ode.dimension" === 1.`);
+                y0 = [config.y0];
+            } else if (Array.isArray(config.y0)) {
+                ASSERT(config.y0.length === ode.dimension, `Chalkboard.diff.solve: Array "y0" must have length ${ode.dimension}.`);
+                for (let i = 0; i < config.y0.length; i++) ASSERT(typeof config.y0[i] === "number" && Number.isFinite(config.y0[i]), `Chalkboard.diff.solve: "y0"[${i}] must be a finite number.`);
+                y0 = config.y0.slice();
+            } else {
+                ASSERT(typeof config.y0 === "object" && config.y0 !== null, `Chalkboard.diff.solve: "y0" must be of type number, number[], or object.`);
+                const y0obj = config.y0 as any;
+                if (ode.type === "single" && ode.order === 2) {
+                    if (("y0" in y0obj) && ("dy0" in y0obj)) {
+                        const a = y0obj.y0;
+                        const b = y0obj.dy0;
+                        ASSERT(typeof a === "number" && Number.isFinite(a) && typeof b === "number" && Number.isFinite(b), `Chalkboard.diff.solve: For second-order scalar, "y0.y0" and "y0.dy0" must be finite numbers.`);
+                        y0 = [a, b];
+                        if (config.returnObject) keys = ["y", "dy"];
+                    } else if (("y" in y0obj) && ("dy" in y0obj)) {
+                        const a = y0obj.y;
+                        const b = y0obj.dy;
+                        ASSERT(typeof a === "number" && Number.isFinite(a) && typeof b === "number" && Number.isFinite(b), `Chalkboard.diff.solve: For second-order scalar, "y0.y" and "y0.dy" must be finite numbers.`);
+                        y0 = [a, b];
+                        if (config.returnObject) keys = ["y", "dy"];
+                    } else {
+                        throw new Error(`Chalkboard.diff.solve: For second-order scalar, provide initial conditions as { y0, dy0 } or { y, dy }.`);
+                    }
+                } else if (ode.dimension === 1 && ("y0" in y0obj) && typeof y0obj.y0 === "number" && Number.isFinite(y0obj.y0)) {
+                    y0 = [y0obj.y0];
+                    if (config.returnObject) keys = ["y"];
+                } else if (ode.dimension === 1 && ("y" in y0obj) && typeof y0obj.y === "number" && Number.isFinite(y0obj.y)) {
+                    y0 = [y0obj.y];
+                    if (config.returnObject) keys = ["y"];
+                } else if ("y0" in y0obj && Array.isArray(y0obj.y0)) {
+                    const arr = y0obj.y0 as number[];
+                    ASSERT(arr.length === ode.dimension, `Chalkboard.diff.solve: Object "y0.y0" must have length ${ode.dimension}.`);
+                    for (let i = 0; i < arr.length; i++) ASSERT(typeof arr[i] === "number" && Number.isFinite(arr[i]), `Chalkboard.diff.solve: y0.y0[${i}] must be a finite number.`);
+                    y0 = arr.slice();
+                } else {
+                    keys = Object.keys(config.y0).sort();
+                    ASSERT(keys.length === ode.dimension, `Chalkboard.diff.solve: Object "y0" must have exactly ${ode.dimension} numeric properties (got ${keys.length}).`);
+                    const arr: number[] = [];
+                    for (let i = 0; i < keys.length; i++) {
+                        const v = (config.y0 as any)[keys[i]];
+                        ASSERT(typeof v === "number" && Number.isFinite(v), `Chalkboard.diff.solve: y0.${keys[i]} must be a finite number.`);
+                        arr.push(v);
+                    }
+                    y0 = arr;
+                }
+            }
+            if (config.returnObject && !keys) {
+                if (ode.type === "single" && ode.order === 2 && ode.dimension === 2) {
+                    keys = ["y", "dy"];
+                } else if (ode.dimension === 1) {
+                    keys = ["y"];
+                } else {
+                    keys = Array.from({ length: ode.dimension }, (_, i) => `y${i + 1}`);
+                }
+            }
+            let h: number;
+            let steps: number;
+            if (typeof config.h === "number") {
+                ASSERT(typeof config.h === "number" && Number.isFinite(config.h) && config.h !== 0, `Chalkboard.diff.solve: "config.h" must be a finite non-zero number.`);
+                h = config.h;
+                steps = Math.max(1, Math.floor(Math.abs((config.t1 - t0) / h)));
+                h = (config.t1 - t0) / steps;
+            } else if (typeof config.steps === "number") {
+                ASSERT(Number.isInteger(config.steps) && config.steps >= 1, `Chalkboard.diff.solve: "config.steps" must be an integer >= 1.`);
+                steps = config.steps;
+                h = (config.t1 - t0) / steps;
+            } else {
+                throw new Error(`Chalkboard.diff.solve: Provide either "config.h" or "config.steps".`);
+            }
+            const add = (a: number[], b: number[]): number[] => Chalkboard.stat.add(a, b);
+            const scl = (a: number[], k: number): number[] => Chalkboard.stat.scl(a, k);
+            const f = ode.rule;
+            const t: number[] = new Array(steps + 1);
+            const y: number[][] = new Array(steps + 1);
+            t[0] = t0;
+            y[0] = y0.slice();
+            const stepper = (() => {
+                if (method === "euler") return (f: (t: number, y: number[]) => number[], t: number, y: number[], h: number): number[] => {
+                    const k1 = f(t, y);
+                    return add(y, scl(k1, h));
+                };
+                if (method === "midpoint") return (f: (t: number, y: number[]) => number[], t: number, y: number[], h: number): number[] => {
+                    const k1 = f(t, y);
+                    const ymid = add(y, scl(k1, h / 2));
+                    const k2 = f(t + h / 2, ymid);
+                    return add(y, scl(k2, h));
+                };
+                if (method === "heun") return (f: (t: number, y: number[]) => number[], t: number, y: number[], h: number): number[] => {
+                    const k1 = f(t, y);
+                    const ypred = add(y, scl(k1, h));
+                    const k2 = f(t + h, ypred);
+                    return add(y, scl(add(k1, k2), h / 2));
+                };
+                if (method === "ralston") return (f: (t: number, y: number[]) => number[], t: number, y: number[], h: number): number[] => {
+                    const k1 = f(t, y);
+                    const y2 = add(y, scl(k1, (2 / 3) * h));
+                    const k2 = f(t + (2 / 3) * h, y2);
+                    return add(y, scl(add(scl(k1, 1 / 4), scl(k2, 3 / 4)), h));
+                };
+                return (f: (t: number, y: number[]) => number[], t: number, y: number[], h: number): number[] => {
+                    const k1 = f(t, y);
+                    const k2 = f(t + h / 2, add(y, scl(k1, h / 2)));
+                    const k3 = f(t + h / 2, add(y, scl(k2, h / 2)));
+                    const k4 = f(t + h, add(y, scl(k3, h)));
+                    const sum23 = add(scl(k2, 2), scl(k3, 2));
+                    const total = add(add(k1, sum23), k4);
+                    return add(y, scl(total, h / 6));
+                };
+            })();
+            for (let i = 0; i < steps; i++) {
+                const ti = t[i];
+                const yi = y[i];
+                const yNext = stepper(f, ti, yi, h);
+                ASSERT(Array.isArray(yNext) && yNext.length === ode.dimension, `Chalkboard.diff.solve: Internal step produced invalid state length (expected ${ode.dimension}).`);
+                for (let k = 0; k < yNext.length; k++) ASSERT(typeof yNext[k] === "number" && Number.isFinite(yNext[k]), `Chalkboard.diff.solve: State became non-finite at step ${i + 1}, index ${k}.`);
+                t[i + 1] = ti + h;
+                y[i + 1] = yNext;
+            }
+            const result: { t: number[]; y: number[][]; yObj?: {[key: string]: number}[]; } = { t, y };
+            if (config.returnObject && keys && keys.length === ode.dimension) {
+                result.yObj = y.map((row) => {
+                    const obj: { [key: string]: number } = {};
+                    for (let i = 0; i < keys.length; i++) obj[keys[i]] = row[i];
+                    return obj;
+                });
+            }
+            return result;
+        };
+    }
+}

--- a/src/Chalkboard-diff.ts
+++ b/src/Chalkboard-diff.ts
@@ -10,7 +10,7 @@ namespace Chalkboard {
      */
     export namespace diff {
         /**
-         * Samples the solution at a time using linear interpolation between the nearest grid points. (No extrapolation as it clamps to endpoints.)
+         * Samples a solution at a time using linear interpolation between the nearest grid points. (No extrapolation as it clamps to endpoints.)
          * @param {{ t: number[]; y: number[][] }} sol - The solution.
          * @param {number} time - The time to sample at.
          * @returns {number[]}
@@ -43,6 +43,35 @@ namespace Chalkboard {
             const P = (typeof p === "number") ? ((t: number) => p) : p;
             const Q = (typeof q === "number") ? ((t: number) => q) : q;
             return Chalkboard.diff.init((t: number, y: number) => -P(t) * y + Q(t) * Math.pow(y, n));
+        };
+
+        /**
+         * Defines a modified Bessel equation of order ν: x^2y'' + xy' - (x^2 + ν^2)y = 0. Equivalent: y'' = -(1/x)y' + (1 + (ν^2/x^2))y. Note: singular at x=0. Start from x>0.
+         * @param {number} nu - Order ν
+         * @returns {ChalkboardODE}
+         */
+        export const BesselI = (nu: number = 0): ChalkboardODE => {
+            ASSERT(typeof nu === "number" && Number.isFinite(nu), `Chalkboard.diff.BesselI: Parameter "nu" must be a finite number.`);
+            return Chalkboard.diff.init((t: number, y: number, dy: number) => {
+                ASSERT(t !== 0, `Chalkboard.diff.BesselI: Singular at t = 0.`);
+                const x = t;
+                return -(1 / x) * dy + (1 + (nu * nu) / (x * x)) * y;
+            });
+        };
+
+        /**
+         * Defines a Bessel equation of order ν: x^2y'' + xy' + (x^2 - ν^2)y = 0. Equivalent: y'' = -(1/x)y' - (1 - (ν^2/x^2))y. Note: singular at x=0. Start from x>0.
+         * @param {number} nu - Order ν
+         * @returns {ChalkboardODE}
+         */
+        export const BesselJ = (nu: number = 0): ChalkboardODE => {
+            ASSERT(typeof nu === "number" && Number.isFinite(nu), `Chalkboard.diff.BesselJ: Parameter "nu" must be a finite number.`);
+            return Chalkboard.diff.init((t: number, y: number, dy: number) => {
+                ASSERT(t !== 0, `Chalkboard.diff.BesselJ: Singular at t = 0.`);
+                const x = t;
+                const term = 1 - (nu * nu) / (x * x);
+                return -(1 / x) * dy - term * y;
+            });
         };
 
         /**
@@ -122,6 +151,71 @@ namespace Chalkboard {
         export const Duffing = (delta: number, alpha: number, beta: number, gamma: number, omega: number): ChalkboardODE => {
             ASSERT([delta, alpha, beta, gamma, omega].every((n) => typeof n === "number" && Number.isFinite(n)), `Chalkboard.diff.Duffing: Parameters must be finite numbers.`);
             return Chalkboard.diff.init((t: number, x: number, v: number) => -delta * v - alpha * x - beta * x * x * x + gamma * Math.cos(omega * t));
+        };
+
+        /**
+         * Calculates a simple residual error diagnostic for a solution: | |y'(t) - f(t,y) ||. Note that y'(t) is estimated from the discrete solution grid (finite differences) and f(t,y) is the ODE right-hand side in canonical first-order system form.
+         * @param {{ t: number[]; y: number[][] }} sol - Solution
+         * @param {ChalkboardODE} ode - ODE which produced the solution
+         * @param {"L1" | "L2" | "LInfinity"} [norm="L2"] - Norm type for the residual per sample
+         * @returns {{ t: number[]; e: number[]; max: number; mean: number; rmse: number; }}
+         * @example
+         * const ode = Chalkboard.diff.init((t, y) => -2 * y);
+         * const sol = Chalkboard.diff.solveAdaptive(ode, {
+         *     t0: 0, t1: 5,
+         *     y0: 1,
+         *     h0: 0.1,
+         *     hMin: 0.01,
+         *     hMax: 0.5
+         * });
+         * const err = Chalkboard.diff.error(sol, ode, "LInfinity");
+         * console.log(err.max);
+         */
+        export const error = (sol: { t: number[]; y: number[][] }, ode: ChalkboardODE, norm: "L1" | "L2" | "LInfinity" = "L2"): { t: number[]; e: number[]; max: number; mean: number; rmse: number } => {
+            ASSERT(sol && Array.isArray(sol.t) && Array.isArray(sol.y), `Chalkboard.diff.error: Invalid solution object.`);
+            ASSERT(sol.t.length === sol.y.length, `Chalkboard.diff.error: "sol.t" and "sol.y" must have the same length.`);
+            ASSERT(sol.t.length >= 2, `Chalkboard.diff.error: Need at least 2 samples to estimate derivative.`);
+            ASSERT(ode && typeof ode === "object" && typeof ode.rule === "function", `Chalkboard.diff.error: Parameter "ode" must be a ChalkboardODE.`);
+            ASSERT(["L1", "L2", "LInfinity"].indexOf(norm) !== -1, `Chalkboard.diff.error: Unknown norm type.`);
+            const t = sol.t;
+            const y = sol.y;
+            const n = y[0].length;
+            ASSERT(Number.isInteger(ode.dimension) && ode.dimension === n, `Chalkboard.diff.error: "ode.dimension" must match solution dimension.`);
+            const dydt = Chalkboard.diff.derivative(sol);
+            const e: number[] = [];
+            let maxErr = 0;
+            let sumErr = 0;
+            let sumSq = 0;
+            for (let i = 0; i < t.length; i++) {
+                const fi = ode.rule(t[i], y[i]);
+                ASSERT(Array.isArray(fi) && fi.length === n, `Chalkboard.diff.error: ODE rule returned invalid derivative at sample ${i}.`);
+                const r: number[] = new Array(n);
+                for (let k = 0; k < n; k++) {
+                    r[k] = dydt[i][k] - fi[k];
+                    ASSERT(typeof r[k] === "number" && Number.isFinite(r[k]), `Chalkboard.diff.error: Non-finite residual at sample ${i}, index ${k}.`);
+                }
+                let ri: number;
+                if (norm === "L1") {
+                    let s = 0;
+                    for (let k = 0; k < n; k++) s += Math.abs(r[k]);
+                    ri = s;
+                } else if (norm === "LInfinity") {
+                    let m = 0;
+                    for (let k = 0; k < n; k++) m = Math.max(m, Math.abs(r[k]));
+                    ri = m;
+                } else {
+                    let s2 = 0;
+                    for (let k = 0; k < n; k++) s2 += r[k] * r[k];
+                    ri = Math.sqrt(s2);
+                }
+                e.push(ri);
+                maxErr = Math.max(maxErr, ri);
+                sumErr += ri;
+                sumSq += ri * ri;
+            }
+            const mean = sumErr / e.length;
+            const rmse = Math.sqrt(sumSq / e.length);
+            return { t: t.slice(), e, max: maxErr, mean, rmse };
         };
 
         /**
@@ -254,6 +348,46 @@ namespace Chalkboard {
         };
 
         /**
+         * Defines a Kepler two-body problem in 2D (inverse-square central force). Unit mass: r'' = -μr / |r|^3. State: [x, y, vx, vy].
+         * @param {number} [mu=1] - Gravitational parameter μ = G(M+m)
+         * @returns {ChalkboardODE}
+         */
+        export const Kepler2D = (mu: number = 1): ChalkboardODE => {
+            ASSERT(typeof mu === "number" && Number.isFinite(mu) && mu >= 0, `Chalkboard.diff.Kepler2D: Parameter "mu" must be a finite number >= 0.`);
+            return Chalkboard.diff.init((t: number, y: number[]) => {
+                const x = y[0], yy = y[1], vx = y[2], vy = y[3];
+                const r2 = x * x + yy * yy;
+                const r = Math.sqrt(r2);
+                ASSERT(r !== 0, `Chalkboard.diff.Kepler2D: Encountered r=0 singularity.`);
+                const invr3 = 1 / (r2 * r);
+                const ax = -mu * x * invr3;
+                const ay = -mu * yy * invr3;
+                return [vx, vy, ax, ay];
+            }, 4);
+        };
+
+        /**
+         * Defines a Kepler two-body problem in 3D (inverse-square central force). Unit mass: r'' = -μr / |r|^3. State: [x, y, z, vx, vy, vz].
+         * @param {number} [mu=1] - Gravitational parameter μ = G(M+m)
+         * @returns {ChalkboardODE}
+         */
+        export const Kepler3D = (mu: number = 1): ChalkboardODE => {
+            ASSERT(typeof mu === "number" && Number.isFinite(mu) && mu >= 0, `Chalkboard.diff.Kepler3D: Parameter "mu" must be a finite number >= 0.`);
+            return Chalkboard.diff.init((t: number, y: number[]) => {
+                const x = y[0], yy = y[1], z = y[2];
+                const vx = y[3], vy = y[4], vz = y[5];
+                const r2 = x * x + yy * yy + z * z;
+                const r = Math.sqrt(r2);
+                ASSERT(r !== 0, `Chalkboard.diff.Kepler3D: Encountered r=0 singularity.`);
+                const invr3 = 1 / (r2 * r);
+                const ax = -mu * x * invr3;
+                const ay = -mu * yy * invr3;
+                const az = -mu * z * invr3;
+                return [vx, vy, vz, ax, ay, az];
+            }, 6);
+        };
+
+        /**
          * Defines a first-order linear scalar ODE: y' = a(t)y + b(t).
          * @param {((t: number) => number) | number} a - Coefficient a(t) or constant a.
          * @param {((t: number) => number) | number} b - Coefficient b(t) or constant b.
@@ -292,6 +426,25 @@ namespace Chalkboard {
         };
 
         /**
+         * Defines a Lorenz attractor: x' = σ (y - x), y' = x (ρ - z) - y, z' = x y - β z, state: [x, y, z].
+         * @param {number} [sigma=10] - σ, Prandtl number
+         * @param {number} [rho=28] - ρ, Rayleigh number
+         * @param {number} [beta=8/3] - β, geometric factor
+         * @returns {ChalkboardODE}
+         */
+        export const Lorenz = (sigma: number = 10, rho: number = 28, beta: number = 8 / 3): ChalkboardODE => {
+            ASSERT([sigma, rho, beta].every((n) => typeof n === "number" && Number.isFinite(n)), `Chalkboard.diff.Lorenz: Parameters must be finite numbers.`);
+            return Chalkboard.diff.init((t: number, y: number[]) => {
+                const x = y[0], yy = y[1], z = y[2];
+                return [
+                    sigma * (yy - x),
+                    x * (rho - z) - yy,
+                    x * yy - beta * z
+                ];
+            }, 3);
+        };
+
+        /**
          * Defines a Lotka–Volterra predator-prey model: x' = αx - βxy, y' = δxy - γy.
          * @param {number} alpha - Prey growth rate
          * @param {number} beta - Predation rate
@@ -322,6 +475,113 @@ namespace Chalkboard {
         };
 
         /**
+         * Defines a pendulum (nonlinear) with optional damping and external torque: θ'' + (b)θ' + (g/L)sin(θ) = τ(t). Equivalent: θ'' = τ(t) - bθ' - (g/L)sin(θ).
+         * @param {number} [params.g=9.81] - Gravity (greater than or equal to 0)
+         * @param {number} [params.L=1] - Length (non-zero)
+         * @param {number} [params.b=0] - Damping coefficient
+         * @param {(t:number)=>number} [params.tau] - External torque τ(t) (0 by default)
+         * @returns {ChalkboardODE}
+         */
+        export const pendulum = (params: { g?: number; L?: number; b?: number; tau?: (t: number) => number; } = {}): ChalkboardODE => {
+            const g = params.g ?? 9.81;
+            const L = params.L ?? 1;
+            const b = params.b ?? 0;
+            const tau = params.tau ?? (() => 0);
+            ASSERT(typeof g === "number" && Number.isFinite(g) && g >= 0, `Chalkboard.diff.pendulum: "g" must be a finite number greater than or equal to 0.`);
+            ASSERT(typeof L === "number" && Number.isFinite(L) && L !== 0, `Chalkboard.diff.pendulum: "L" must be a finite non-zero number.`);
+            ASSERT(typeof b === "number" && Number.isFinite(b), `Chalkboard.diff.pendulum: "b" must be a finite number.`);
+            ASSERT(typeof tau === "function", `Chalkboard.diff.pendulum: "tau" must be a function.`);
+            return Chalkboard.diff.init((t, theta, omega) => tau(t) - b * omega - (g / L) * Math.sin(theta));
+        };
+
+        /**
+         * Defines a pendulum with linear (viscous) and quadratic (turbulent-ish) drag: θ'' + bθ' + c|θ'|θ' + (g/L)sin(θ) = τ(t). Equivalent: θ'' = τ(t) - bθ' - c|θ'|θ' - (g/L)sin(θ).
+         * @param {number} [params.g=9.81] - Gravity (greater than or equal to 0)
+         * @param {number} [params.L=1] - Length (non-zero)
+         * @param {number} [params.b=0] - Linear damping coefficient
+         * @param {number} [params.c=0] - Quadratic damping coefficient
+         * @param {(t:number)=>number} [params.tau] - External torque τ(t) (0 by default)
+         * @returns {ChalkboardODE}
+         */
+        export const pendulumDrag = (params: { g?: number; L?: number; b?: number; c?: number; tau?: (t: number) => number; } = {}): ChalkboardODE => {
+            const g = params.g ?? 9.81;
+            const L = params.L ?? 1;
+            const b = params.b ?? 0;
+            const c = params.c ?? 0;
+            const tau = params.tau ?? (() => 0);
+            ASSERT(typeof g === "number" && Number.isFinite(g) && g >= 0, `Chalkboard.diff.pendulumDrag: "g" must be a finite number greater than or equal to 0.`);
+            ASSERT(typeof L === "number" && Number.isFinite(L) && L !== 0, `Chalkboard.diff.pendulumDrag: "L" must be a finite non-zero number.`);
+            ASSERT(typeof b === "number" && Number.isFinite(b), `Chalkboard.diff.pendulumDrag: "b" must be a finite number.`);
+            ASSERT(typeof c === "number" && Number.isFinite(c), `Chalkboard.diff.pendulumDrag: "c" must be a finite number.`);
+            ASSERT(typeof tau === "function", `Chalkboard.diff.pendulumDrag: "tau" must be a function.`);
+            return Chalkboard.diff.init((t, theta, omega) => {
+                const quad = c * Math.abs(omega) * omega;
+                return tau(t) - b * omega - quad - (g / L) * Math.sin(theta);
+            });
+        };
+
+        /**
+         * Defines a driven damped pendulum in a common parameterization: θ'' + qθ' + sin(θ) = Acos(Ωt). Equivalent: θ'' = Acos(Ωt) - qθ' - sin(θ). This is the dimensionless form (g/L scaled out).
+         * @param {number} [q=0.5] - Damping
+         * @param {number} [A=1.2] - Drive amplitude
+         * @param {number} [Omega=2/3] - Drive frequency
+         * @returns {ChalkboardODE}
+         */
+        export const pendulumDriven = (q: number = 0.5, A: number = 1.2, Omega: number = 2 / 3): ChalkboardODE => {
+            ASSERT([q, A, Omega].every((n) => typeof n === "number" && Number.isFinite(n)), `Chalkboard.diff.pendulumDriven: Parameters must be finite numbers.`);
+            return Chalkboard.diff.init((t, theta, omega) => A * Math.cos(Omega * t) - q * omega - Math.sin(theta));
+        };
+
+        /**
+         * Returns phase-plot data from a solution of an ODE (pairs of components). Useful for plotting trajectories such as (y, dy), (x, y), (x, z), etc.
+         * @param {{ t: number[]; y: number[][] }} sol - Solution of an ODE
+         * @param {number} i - The first component index
+         * @param {number} j - The second component index
+         * @returns {number[][]}
+         * @example
+         * // Phase plot of harmonic oscillator (y vs dy)
+         * const ode = Chalkboard.diff.harmonic();
+         * const sol = Chalkboard.diff.solve(ode, { t0: 0, t1: 20, steps: 2000, y0: { y0: 1, dy0: 0 } });
+         * const data = Chalkboard.diff.phase(sol, 0, 1);
+         */
+        export const phase = (sol: { t: number[]; y: number[][] }, i: number, j: number): number[][] => {
+            ASSERT(sol && Array.isArray(sol.t) && Array.isArray(sol.y), `Chalkboard.diff.phase: Invalid solution object.`);
+            ASSERT(sol.t.length === sol.y.length, `Chalkboard.diff.phase: "sol.t" and "sol.y" must have the same length.`);
+            ASSERT(sol.y.length > 0, `Chalkboard.diff.phase: Solution has no samples.`);
+            ASSERT(Number.isInteger(i) && i >= 0, `Chalkboard.diff.phase: Parameter "i" must be an integer >= 0.`);
+            ASSERT(Number.isInteger(j) && j >= 0, `Chalkboard.diff.phase: Parameter "j" must be an integer >= 0.`);
+            ASSERT(i !== j, `Chalkboard.diff.phase: Parameters "i" and "j" must be different indices.`);
+            ASSERT(i < sol.y[0].length && j < sol.y[0].length, `Chalkboard.diff.phase: Indices out of bounds for solution dimension.`);
+            const result: number[][] = [];
+            for (let k = 0; k < sol.y.length; k++) {
+                const row = sol.y[k];
+                result.push([row[i], row[j]]);
+            }
+            return result;
+        };
+
+        /**
+         * Samples the solution at multiple times using Chalkboard.diff.at.
+         * @param {{ t: number[]; y: number[][] }} sol - Solution of an ODE
+         * @param {number[]} times - Times to sample at
+         * @returns {number[][]}
+         * @example
+         * const ode = Chalkboard.diff.harmonic();
+         * const sol = Chalkboard.diff.solve(ode, { t0: 0, t1: 20, steps: 2000, y0: { y0: 1, dy0: 0 } });
+         * const ys = Chalkboard.diff.sample(sol, [0, 0.5, 1.0, 1.5, 2.0]);
+         */
+        export const sample = (sol: { t: number[]; y: number[][] }, times: number[]): number[][] => {
+            ASSERT(sol && Array.isArray(sol.t) && Array.isArray(sol.y), `Chalkboard.diff.sample: Invalid solution object.`);
+            ASSERT(Array.isArray(times), `Chalkboard.diff.sample: Parameter "times" must be an array.`);
+            const result: number[][] = [];
+            for (let i = 0; i < times.length; i++) {
+                ASSERT(typeof times[i] === "number" && Number.isFinite(times[i]), `Chalkboard.diff.sample: "times"[${i}] must be a finite number.`);
+                result.push(Chalkboard.diff.at(sol, times[i]));
+            }
+            return result;
+        };
+
+        /**
          * Defines a separable ODE: y' = f(t)g(y)
          * @param {(t: number) => number} f - f(t)
          * @param {(y: number) => number} g - g(y)
@@ -333,7 +593,28 @@ namespace Chalkboard {
         };
 
         /**
-         * Defines an SIR epidemic model: S' = -βSI, I' = βSI - γI, R' = γI.
+         * Defines a SEIR epidemic model: S' = -βSI, E' = βSI - σE, I' = σE - γI, R' = γI.
+         * @param {number} beta - Infection rate
+         * @param {number} sigma - Incubation rate
+         * @param {number} gamma - Recovery rate
+         * @returns {ChalkboardODE}
+         */
+        export const SEIR = (beta: number = 1, sigma: number = 1, gamma: number = 1): ChalkboardODE => {
+            ASSERT([beta, sigma, gamma].every((n) => typeof n === "number" && Number.isFinite(n)), `Chalkboard.diff.SEIR: Parameters must be finite numbers.`);
+            return Chalkboard.diff.init((t: number, y: number[]) => {
+                const S = y[0], E = y[1], I = y[2], R = y[3];
+                const inf = beta * S * I;
+                return [
+                    -inf,
+                    inf - sigma * E,
+                    sigma * E - gamma * I,
+                    gamma * I
+                ];
+            }, 4);
+        };
+
+        /**
+         * Defines a SIR epidemic model: S' = -βSI, I' = βSI - γI, R' = γI.
          * @param {number} beta - Infection rate
          * @param {number} gamma - Recovery rate
          * @returns {ChalkboardODE}
@@ -347,9 +628,19 @@ namespace Chalkboard {
         };
 
         /**
+         * Defines a SIS epidemic model with total population normalized to 1: S + I = 1, I' = βI(1 - I) - γI.
+         * @param {number} beta - Infection rate
+         * @param {number} gamma - Recovery rate
+         * @returns {ChalkboardODE}
+         */
+        export const SIS = (beta: number = 1, gamma: number = 0.5): ChalkboardODE => {
+            ASSERT([beta, gamma].every((n) => typeof n === "number" && Number.isFinite(n)), `Chalkboard.diff.SIS: Parameters must be finite numbers.`);
+            return Chalkboard.diff.init((t: number, I: number) => beta * I * (1 - I) - gamma * I);
+        };
+
+        /**
          * Solves an ordinary differential equation using an explicit method.
          * @param {ChalkboardODE} ode - The ordinary differential equation to solve.
-         * @param {Object} config - The solver configuration object.
          * @param {number} [config.t0=0] - The initial time.
          * @param {number} config.t1 - The final time.
          * @param {number} [config.h] - The time step size. Either this or `steps` must be provided.
@@ -529,6 +820,235 @@ namespace Chalkboard {
                 y[i + 1] = yNext;
             }
             const result: { t: number[]; y: number[][]; yObj?: {[key: string]: number}[]; } = { t, y };
+            if (config.returnObject && keys && keys.length === ode.dimension) {
+                result.yObj = y.map((row) => {
+                    const obj: { [key: string]: number } = {};
+                    for (let i = 0; i < keys.length; i++) obj[keys[i]] = row[i];
+                    return obj;
+                });
+            }
+            return result;
+        };
+
+        /**
+         * Solves an ordinary differential equation using the adaptive Dormand–Prince RK45 method. Produces a variable-step solution.
+         * @param {ChalkboardODE} ode - The ordinary differential equation to solve.
+         * @param {number} [config.t0=0] - Initial time.
+         * @param {number} config.t1 - Final time.
+         * @param {number | number[] | Object} config.y0 - Initial state (same conventions as Chalkboard.diff.solve).
+         * @param {number} [config.h0] - Initial step guess.
+         * @param {number} [config.hMin] - Minimum step size magnitude.
+         * @param {number} [config.hMax] - Maximum step size magnitude.
+         * @param {number} [config.rtol=1e-6] - Relative tolerance.
+         * @param {number} [config.atol=1e-9] - Absolute tolerance.
+         * @param {number} [config.maxSteps=100000] - Maximum accepted+rejected iterations.
+         * @param {boolean} [config.returnObject=false] - Whether to return yObj (same as Chalkboard.diff.solve).
+         * @returns {{ t: number[]; y: number[][]; yObj?: {[key: string]: number}[]; }}
+         * @example
+         * // Solve first-order ODE with adaptive RK45:
+         * const ode1 = Chalkboard.diff.init((t, y) => -2 * y);
+         * const sol1 = Chalkboard.diff.solveAdaptive(ode1, {
+         *     t0: 0, t1: 5,
+         *     y0: 1,
+         *     h0: 0.1,
+         *     hMin: 0.01,
+         *     hMax: 0.5
+         * });
+         * 
+         * // Solve second-order ODE with adaptive RK45:
+         * const ode2 = Chalkboard.diff.init((t, y, dy) => dy - y);
+         * const sol2 = Chalkboard.diff.solveAdaptive(ode2, {
+         *     t0: 0, t1: 10,
+         *     y0: { y0: 1, dy0: 0 },
+         *     h0: 0.1,
+         *     hMin: 0.01,
+         *     hMax: 0.5,
+         *     returnObject: true
+         * });
+         * 
+         * // Solve system ODE with adaptive RK45:
+         * const odeSys = Chalkboard.diff.init((t, y) => [y[1], -y[0]], 2);
+         * const solSys = Chalkboard.diff.solveAdaptive(odeSys, {
+         *     t0: 0, t1: 10,
+         *     y0: [1, 0],
+         *     h0: 0.1,
+         *     hMin: 0.01,
+         *     hMax: 0.5
+         * });
+         */
+        export const solveAdaptive = (
+            ode: ChalkboardODE,
+            config: {
+                t0?: number;
+                t1: number;
+                y0: number | number[] | Record<string, any>;
+                h0?: number;
+                hMin?: number;
+                hMax?: number;
+                rtol?: number;
+                atol?: number;
+                maxSteps?: number;
+                returnObject?: boolean;
+            }
+        ): { t: number[]; y: number[][]; yObj?: { [key: string]: number }[] } => {
+            ASSERT(ode && typeof ode === "object", `Chalkboard.diff.solveAdaptive: Parameter "ode" must be a ChalkboardODE.`);
+            ASSERT(typeof ode.rule === "function", `Chalkboard.diff.solveAdaptive: "ode.rule" must be a function.`);
+            ASSERT(Number.isInteger(ode.dimension) && ode.dimension >= 1, `Chalkboard.diff.solveAdaptive: "ode.dimension" must be an integer >= 1.`);
+            ASSERT(typeof config === "object" && config !== null, `Chalkboard.diff.solveAdaptive: Parameter "config" must be an object.`);
+            ASSERT(typeof config.t1 === "number" && Number.isFinite(config.t1), `Chalkboard.diff.solveAdaptive: "config.t1" must be a finite number.`);
+            const t0 = config.t0 ?? 0;
+            ASSERT(typeof t0 === "number" && Number.isFinite(t0), `Chalkboard.diff.solveAdaptive: "config.t0" must be a finite number.`);
+            ASSERT(config.t1 !== t0, `Chalkboard.diff.solveAdaptive: "config.t1" must be different from "config.t0".`);
+            const rtol = config.rtol ?? 1e-6;
+            const atol = config.atol ?? 1e-9;
+            ASSERT(typeof rtol === "number" && Number.isFinite(rtol) && rtol > 0, `Chalkboard.diff.solveAdaptive: "rtol" must be > 0.`);
+            ASSERT(typeof atol === "number" && Number.isFinite(atol) && atol >= 0, `Chalkboard.diff.solveAdaptive: "atol" must be >= 0.`);
+            const maxSteps = config.maxSteps ?? 100000;
+            ASSERT(Number.isInteger(maxSteps) && maxSteps >= 1, `Chalkboard.diff.solveAdaptive: "maxSteps" must be an integer >= 1.`);
+            let y0: number[];
+            let keys: string[] | undefined;
+            if (typeof config.y0 === "number" && Number.isFinite(config.y0)) {
+                ASSERT(ode.dimension === 1, `Chalkboard.diff.solveAdaptive: Scalar "y0" is only allowed when "ode.dimension" === 1.`);
+                y0 = [config.y0];
+            } else if (Array.isArray(config.y0)) {
+                ASSERT(config.y0.length === ode.dimension, `Chalkboard.diff.solveAdaptive: Array "y0" must have length ${ode.dimension}.`);
+                for (let i = 0; i < config.y0.length; i++) ASSERT(typeof config.y0[i] === "number" && Number.isFinite(config.y0[i]), `Chalkboard.diff.solveAdaptive: "y0"[${i}] must be a finite number.`);
+                y0 = config.y0.slice();
+            } else {
+                ASSERT(typeof config.y0 === "object" && config.y0 !== null, `Chalkboard.diff.solveAdaptive: "y0" must be of type number, number[], or object.`);
+                const y0obj = config.y0 as any;
+                if (ode.type === "single" && ode.order === 2) {
+                    if (("y0" in y0obj) && ("dy0" in y0obj)) {
+                        const a = y0obj.y0;
+                        const b = y0obj.dy0;
+                        ASSERT(typeof a === "number" && Number.isFinite(a) && typeof b === "number" && Number.isFinite(b), `Chalkboard.diff.solveAdaptive: For second-order scalar, "y0.y0" and "y0.dy0" must be finite numbers.`);
+                        y0 = [a, b];
+                        if (config.returnObject) keys = ["y", "dy"];
+                    } else if (("y" in y0obj) && ("dy" in y0obj)) {
+                        const a = y0obj.y;
+                        const b = y0obj.dy;
+                        ASSERT(typeof a === "number" && Number.isFinite(a) && typeof b === "number" && Number.isFinite(b), `Chalkboard.diff.solveAdaptive: For second-order scalar, "y0.y" and "y0.dy" must be finite numbers.`);
+                        y0 = [a, b];
+                        if (config.returnObject) keys = ["y", "dy"];
+                    } else {
+                        throw new Error(`Chalkboard.diff.solveAdaptive: For second-order scalar, provide initial conditions as { y0, dy0 } or { y, dy }.`);
+                    }
+                } else if (ode.dimension === 1 && ("y0" in y0obj) && typeof y0obj.y0 === "number" && Number.isFinite(y0obj.y0)) {
+                    y0 = [y0obj.y0];
+                    if (config.returnObject) keys = ["y"];
+                } else if (ode.dimension === 1 && ("y" in y0obj) && typeof y0obj.y === "number" && Number.isFinite(y0obj.y)) {
+                    y0 = [y0obj.y];
+                    if (config.returnObject) keys = ["y"];
+                } else if ("y0" in y0obj && Array.isArray(y0obj.y0)) {
+                    const arr = y0obj.y0 as number[];
+                    ASSERT(arr.length === ode.dimension, `Chalkboard.diff.solveAdaptive: Object "y0.y0" must have length ${ode.dimension}.`);
+                    for (let i = 0; i < arr.length; i++) ASSERT(typeof arr[i] === "number" && Number.isFinite(arr[i]), `Chalkboard.diff.solveAdaptive: y0.y0[${i}] must be a finite number.`);
+                    y0 = arr.slice();
+                } else {
+                    keys = Object.keys(config.y0).sort();
+                    ASSERT(keys.length === ode.dimension, `Chalkboard.diff.solveAdaptive: Object "y0" must have exactly ${ode.dimension} numeric properties (got ${keys.length}).`);
+                    const arr: number[] = [];
+                    for (let i = 0; i < keys.length; i++) {
+                        const v = (config.y0 as any)[keys[i]];
+                        ASSERT(typeof v === "number" && Number.isFinite(v), `Chalkboard.diff.solveAdaptive: y0.${keys[i]} must be a finite number.`);
+                        arr.push(v);
+                    }
+                    y0 = arr;
+                }
+            }
+            if (config.returnObject && !keys) {
+                if (ode.type === "single" && ode.order === 2 && ode.dimension === 2) keys = ["y", "dy"];
+                else if (ode.dimension === 1) keys = ["y"];
+                else keys = Array.from({ length: ode.dimension }, (_, i) => `y${i + 1}`);
+            }
+            const sign = Math.sign(config.t1 - t0);
+            let h = config.h0 ?? (config.t1 - t0) / 100;
+            ASSERT(typeof h === "number" && Number.isFinite(h) && h !== 0, `Chalkboard.diff.solveAdaptive: "h0" must be a finite non-zero number (or omitted).`);
+            h = Math.abs(h) * sign;
+            const hMin = (config.hMin ?? 1e-12);
+            const hMax = (config.hMax ?? Math.abs(config.t1 - t0));
+            ASSERT(typeof hMin === "number" && Number.isFinite(hMin) && hMin > 0, `Chalkboard.diff.solveAdaptive: "hMin" must be > 0.`);
+            ASSERT(typeof hMax === "number" && Number.isFinite(hMax) && hMax > 0, `Chalkboard.diff.solveAdaptive: "hMax" must be > 0.`);
+            const clampAbs = (value: number, minAbs: number, maxAbs: number): number => {
+                const s = Math.sign(value) || 1;
+                const a = Math.min(maxAbs, Math.max(minAbs, Math.abs(value)));
+                return s * a;
+            };
+            const add = (a: number[], b: number[]): number[] => Chalkboard.stat.add(a, b);
+            const scl = (a: number[], k: number): number[] => Chalkboard.stat.scl(a, k);
+            const f = ode.rule;
+            const t: number[] = [t0];
+            const y: number[][] = [y0.slice()];
+            const c2 = 1 / 5;
+            const c3 = 3 / 10;
+            const c4 = 4 / 5;
+            const c5 = 8 / 9;
+            const c6 = 1;
+            const c7 = 1;
+            const a21 = 1 / 5;
+            const a31 = 3 / 40, a32 = 9 / 40;
+            const a41 = 44 / 45, a42 = -56 / 15, a43 = 32 / 9;
+            const a51 = 19372 / 6561, a52 = -25360 / 2187, a53 = 64448 / 6561, a54 = -212 / 729;
+            const a61 = 9017 / 3168, a62 = -355 / 33, a63 = 46732 / 5247, a64 = 49 / 176, a65 = -5103 / 18656;
+            const a71 = 35 / 384, a72 = 0, a73 = 500 / 1113, a74 = 125 / 192, a75 = -2187 / 6784, a76 = 11 / 84;
+            const b1 = 35 / 384, b2 = 0, b3 = 500 / 1113, b4 = 125 / 192, b5 = -2187 / 6784, b6 = 11 / 84, b7 = 0;
+            const bs1 = 5179 / 57600, bs2 = 0, bs3 = 7571 / 16695, bs4 = 393 / 640, bs5 = -92097 / 339200, bs6 = 187 / 2100, bs7 = 1 / 40;
+            const errNorm = (y5: number[], y4: number[], yScale: number[]): number => {
+                let m = 0;
+                for (let i = 0; i < y5.length; i++) {
+                    const e = Math.abs(y5[i] - y4[i]) / yScale[i];
+                    if (e > m) m = e;
+                }
+                return m;
+            };
+            const makeScale = (yCurr: number[], yNext: number[]): number[] => {
+                const s: number[] = [];
+                for (let i = 0; i < yCurr.length; i++) s.push(atol + rtol * Math.max(Math.abs(yCurr[i]), Math.abs(yNext[i])));
+                return s;
+            };
+            let iter = 0;
+            while (iter < maxSteps) {
+                iter++;
+                const ti = t[t.length - 1];
+                const yi = y[y.length - 1];
+                if ((sign > 0 && ti >= config.t1) || (sign < 0 && ti <= config.t1)) break;
+                const remaining = config.t1 - ti;
+                if (Math.abs(h) > Math.abs(remaining)) h = remaining;
+                h = clampAbs(h, hMin, hMax);
+                const k1 = f(ti, yi);
+                const y2 = add(yi, scl(k1, h * a21));
+                const k2 = f(ti + c2 * h, y2);
+                const y3 = add(add(yi, scl(k1, h * a31)), scl(k2, h * a32));
+                const k3 = f(ti + c3 * h, y3);
+                const y4 = add(add(add(yi, scl(k1, h * a41)), scl(k2, h * a42)), scl(k3, h * a43));
+                const k4 = f(ti + c4 * h, y4);
+                const y5s = add(add(add(add(yi, scl(k1, h * a51)), scl(k2, h * a52)), scl(k3, h * a53)), scl(k4, h * a54));
+                const k5 = f(ti + c5 * h, y5s);
+                const y6 = add(add(add(add(add(yi, scl(k1, h * a61)), scl(k2, h * a62)), scl(k3, h * a63)), scl(k4, h * a64)), scl(k5, h * a65));
+                const k6 = f(ti + c6 * h, y6);
+                const y7 = add(add(add(add(add(add(yi, scl(k1, h * a71)), scl(k2, h * a72)), scl(k3, h * a73)), scl(k4, h * a74)), scl(k5, h * a75)), scl(k6, h * a76));
+                const k7 = f(ti + c7 * h, y7);
+                const yNext5 = add(yi, scl(add(add(add(scl(k1, b1), scl(k2, b2)), add(scl(k3, b3), scl(k4, b4))), add(add(scl(k5, b5), scl(k6, b6)), scl(k7, b7))), h));
+                const yNext4 = add(yi, scl(add(add(add(scl(k1, bs1), scl(k2, bs2)), add(scl(k3, bs3), scl(k4, bs4))), add(add(scl(k5, bs5), scl(k6, bs6)), scl(k7, bs7))), h));
+                const scale = makeScale(yi, yNext5);
+                const e = errNorm(yNext5, yNext4, scale);
+                const safety = 0.9;
+                const minFactor = 0.2;
+                const maxFactor = 5.0;
+                if (e <= 1) {
+                    const tNext = ti + h;
+                    t.push(tNext);
+                    y.push(yNext5);
+                    const factor = e === 0 ? maxFactor : Math.min(maxFactor, Math.max(minFactor, safety * Math.pow(1 / e, 1 / 5)));
+                    h = h * factor;
+                } else {
+                    const factor = Math.min(1.0, Math.max(minFactor, safety * Math.pow(1 / e, 1 / 5)));
+                    h = h * factor;
+                    if (Math.abs(h) < hMin) throw new Error(`Chalkboard.diff.solveAdaptive: Step size underflow (h < hMin).`);
+                }
+            }
+            if (iter >= maxSteps) throw new Error(`Chalkboard.diff.solveAdaptive: Exceeded maxSteps=${maxSteps}.`);
+            const result: { t: number[]; y: number[][]; yObj?: { [key: string]: number }[] } = { t, y };
             if (config.returnObject && keys && keys.length === ode.dimension) {
                 result.yObj = y.map((row) => {
                     const obj: { [key: string]: number } = {};

--- a/src/Chalkboard-matr.ts
+++ b/src/Chalkboard-matr.ts
@@ -73,18 +73,9 @@ namespace Chalkboard {
             if (Chalkboard.matr.isSizeOf(matr, 2)) {
                 return Chalkboard.matr.init([Math.abs(matr[0][0]), Math.abs(matr[0][1])], [Math.abs(matr[1][0]), Math.abs(matr[1][1])]);
             } else if (Chalkboard.matr.isSizeOf(matr, 3)) {
-                return Chalkboard.matr.init(
-                    [Math.abs(matr[0][0]), Math.abs(matr[0][1]), Math.abs(matr[0][2])],
-                    [Math.abs(matr[1][0]), Math.abs(matr[1][1]), Math.abs(matr[1][2])],
-                    [Math.abs(matr[2][0]), Math.abs(matr[2][1]), Math.abs(matr[2][2])]
-                );
+                return Chalkboard.matr.init([Math.abs(matr[0][0]), Math.abs(matr[0][1]), Math.abs(matr[0][2])], [Math.abs(matr[1][0]), Math.abs(matr[1][1]), Math.abs(matr[1][2])], [Math.abs(matr[2][0]), Math.abs(matr[2][1]), Math.abs(matr[2][2])]);
             } else if (Chalkboard.matr.isSizeOf(matr, 4)) {
-                return Chalkboard.matr.init(
-                    [Math.abs(matr[0][0]), Math.abs(matr[0][1]), Math.abs(matr[0][2]), Math.abs(matr[0][3])],
-                    [Math.abs(matr[1][0]), Math.abs(matr[1][1]), Math.abs(matr[1][2]), Math.abs(matr[1][3])],
-                    [Math.abs(matr[2][0]), Math.abs(matr[2][1]), Math.abs(matr[2][2]), Math.abs(matr[2][3])],
-                    [Math.abs(matr[3][0]), Math.abs(matr[3][1]), Math.abs(matr[3][2]), Math.abs(matr[3][3])]
-                );
+                return Chalkboard.matr.init([Math.abs(matr[0][0]), Math.abs(matr[0][1]), Math.abs(matr[0][2]), Math.abs(matr[0][3])], [Math.abs(matr[1][0]), Math.abs(matr[1][1]), Math.abs(matr[1][2]), Math.abs(matr[1][3])], [Math.abs(matr[2][0]), Math.abs(matr[2][1]), Math.abs(matr[2][2]), Math.abs(matr[2][3])], [Math.abs(matr[3][0]), Math.abs(matr[3][1]), Math.abs(matr[3][2]), Math.abs(matr[3][3])]);
             } else {
                 const result = Chalkboard.matr.init();
                 for (let i = 0; i < Chalkboard.matr.rows(matr); i++) {
@@ -106,7 +97,10 @@ namespace Chalkboard {
         export const add = (matr1: ChalkboardMatrix, matr2: ChalkboardMatrix): ChalkboardMatrix => {
             if (Chalkboard.matr.isSizeEqual(matr1, matr2)) {
                 if (Chalkboard.matr.isSizeOf(matr1, 2)) {
-                    return Chalkboard.matr.init([matr1[0][0] + matr2[0][0], matr1[0][1] + matr2[0][1]], [matr1[1][0] + matr2[1][0], matr1[1][1] + matr2[1][1]]);
+                    return Chalkboard.matr.init(
+                        [matr1[0][0] + matr2[0][0], matr1[0][1] + matr2[0][1]],
+                        [matr1[1][0] + matr2[1][0], matr1[1][1] + matr2[1][1]]
+                    );
                 } else if (Chalkboard.matr.isSizeOf(matr1, 3)) {
                     return Chalkboard.matr.init(
                         [matr1[0][0] + matr2[0][0], matr1[0][1] + matr2[0][1], matr1[0][2] + matr2[0][2]],
@@ -171,12 +165,7 @@ namespace Chalkboard {
          * @returns {ChalkboardMatrix}
          */
         export const cofactor = (matr: ChalkboardMatrix, row: number, col: number): ChalkboardMatrix => {
-            return matr
-                .slice(0, row)
-                .concat(matr.slice(row + 1))
-                .map(function (row) {
-                    return row.slice(0, col).concat(row.slice(col + 1));
-                });
+            return matr.slice(0, row).concat(matr.slice(row + 1)).map((row) => row.slice(0, col).concat(row.slice(col + 1)));
         };
 
         /**
@@ -208,7 +197,10 @@ namespace Chalkboard {
             if (axis === 0) {
                 if (Chalkboard.matr.cols(matr1) === Chalkboard.matr.cols(matr2)) {
                     if (Chalkboard.matr.isSizeOf(matr1, 2) && Chalkboard.matr.rows(matr2) === 2) {
-                        return Chalkboard.matr.init([matr1[0][0], matr1[0][1]], [matr1[1][0], matr1[1][1]], [matr2[0][0], matr2[0][1]], [matr2[1][0], matr2[1][1]]);
+                        return Chalkboard.matr.init(
+                            [matr1[0][0], matr1[0][1]], [matr1[1][0], matr1[1][1]],
+                            [matr2[0][0], matr2[0][1]], [matr2[1][0], matr2[1][1]]
+                        );
                     } else if (Chalkboard.matr.isSizeOf(matr1, 3) && Chalkboard.matr.rows(matr2) === 3) {
                         return Chalkboard.matr.init(
                             [matr1[0][0], matr1[0][1], matr1[0][2]],
@@ -238,7 +230,10 @@ namespace Chalkboard {
             } else if (axis === 1) {
                 if (Chalkboard.matr.rows(matr1) === Chalkboard.matr.rows(matr2)) {
                     if (Chalkboard.matr.isSizeOf(matr1, 2) && Chalkboard.matr.cols(matr2) === 2) {
-                        return Chalkboard.matr.init([matr1[0][0], matr1[0][1], matr2[0][0], matr2[0][1]], [matr1[1][0], matr1[1][1], matr2[1][0], matr2[1][1]]);
+                        return Chalkboard.matr.init(
+                            [matr1[0][0], matr1[0][1], matr2[0][0], matr2[0][1]],
+                            [matr1[1][0], matr1[1][1], matr2[1][0], matr2[1][1]]
+                        );
                     } else if (Chalkboard.matr.isSizeOf(matr1, 3) && Chalkboard.matr.cols(matr2) === 3) {
                         return Chalkboard.matr.init(
                             [matr1[0][0], matr1[0][1], matr1[0][2], matr2[0][0], matr2[0][1], matr2[0][2]],
@@ -287,30 +282,10 @@ namespace Chalkboard {
                 );
             } else if (Chalkboard.matr.isSizeOf(matr, 4)) {
                 return Chalkboard.matr.init(
-                    [
-                        Chalkboard.numb.constrain(matr[0][0], range),
-                        Chalkboard.numb.constrain(matr[0][1], range),
-                        Chalkboard.numb.constrain(matr[0][2], range),
-                        Chalkboard.numb.constrain(matr[0][3], range)
-                    ],
-                    [
-                        Chalkboard.numb.constrain(matr[1][0], range),
-                        Chalkboard.numb.constrain(matr[1][1], range),
-                        Chalkboard.numb.constrain(matr[1][2], range),
-                        Chalkboard.numb.constrain(matr[1][3], range)
-                    ],
-                    [
-                        Chalkboard.numb.constrain(matr[2][0], range),
-                        Chalkboard.numb.constrain(matr[2][1], range),
-                        Chalkboard.numb.constrain(matr[2][2], range),
-                        Chalkboard.numb.constrain(matr[2][3], range)
-                    ],
-                    [
-                        Chalkboard.numb.constrain(matr[3][0], range),
-                        Chalkboard.numb.constrain(matr[3][1], range),
-                        Chalkboard.numb.constrain(matr[3][2], range),
-                        Chalkboard.numb.constrain(matr[3][3], range)
-                    ]
+                    [Chalkboard.numb.constrain(matr[0][0], range), Chalkboard.numb.constrain(matr[0][1], range), Chalkboard.numb.constrain(matr[0][2], range), Chalkboard.numb.constrain(matr[0][3], range)],
+                    [Chalkboard.numb.constrain(matr[1][0], range), Chalkboard.numb.constrain(matr[1][1], range), Chalkboard.numb.constrain(matr[1][2], range), Chalkboard.numb.constrain(matr[1][3], range)],
+                    [Chalkboard.numb.constrain(matr[2][0], range), Chalkboard.numb.constrain(matr[2][1], range), Chalkboard.numb.constrain(matr[2][2], range), Chalkboard.numb.constrain(matr[2][3], range)],
+                    [Chalkboard.numb.constrain(matr[3][0], range), Chalkboard.numb.constrain(matr[3][1], range), Chalkboard.numb.constrain(matr[3][2], range), Chalkboard.numb.constrain(matr[3][3], range)]
                 );
             } else {
                 const result = Chalkboard.matr.init();
@@ -335,12 +310,7 @@ namespace Chalkboard {
             } else if (Chalkboard.matr.isSizeOf(matr, 3)) {
                 return Chalkboard.matr.init([matr[0][0], matr[0][1], matr[0][2]], [matr[1][0], matr[1][1], matr[1][2]], [matr[2][0], matr[2][1], matr[2][2]]);
             } else if (Chalkboard.matr.isSizeOf(matr, 4)) {
-                return Chalkboard.matr.init(
-                    [matr[0][0], matr[0][1], matr[0][2], matr[0][3]],
-                    [matr[1][0], matr[1][1], matr[1][2], matr[1][3]],
-                    [matr[2][0], matr[2][1], matr[2][2], matr[2][3]],
-                    [matr[3][0], matr[3][1], matr[3][2], matr[3][3]]
-                );
+                return Chalkboard.matr.init([matr[0][0], matr[0][1], matr[0][2], matr[0][3]], [matr[1][0], matr[1][1], matr[1][2], matr[1][3]], [matr[2][0], matr[2][1], matr[2][2], matr[2][3]], [matr[3][0], matr[3][1], matr[3][2], matr[3][3]]);
             } else {
                 const result = Chalkboard.matr.init();
                 for (let i = 0; i < Chalkboard.matr.rows(matr); i++) {
@@ -365,30 +335,9 @@ namespace Chalkboard {
                 } else if (Chalkboard.matr.rows(matr) === 2) {
                     return matr[0][0] * matr[1][1] - matr[0][1] * matr[1][0];
                 } else if (Chalkboard.matr.rows(matr) === 3) {
-                    return (
-                        matr[0][0] * (matr[1][1] * matr[2][2] - matr[1][2] * matr[2][1]) -
-                        matr[0][1] * (matr[1][0] * matr[2][2] - matr[1][2] * matr[2][0]) +
-                        matr[0][2] * (matr[1][0] * matr[2][1] - matr[1][1] * matr[2][0])
-                    );
+                    return matr[0][0] * (matr[1][1] * matr[2][2] - matr[1][2] * matr[2][1]) - matr[0][1] * (matr[1][0] * matr[2][2] - matr[1][2] * matr[2][0]) + matr[0][2] * (matr[1][0] * matr[2][1] - matr[1][1] * matr[2][0]);
                 } else if (Chalkboard.matr.rows(matr) === 4) {
-                    return (
-                        matr[0][0] *
-                            (matr[1][1] * (matr[2][2] * matr[3][3] - matr[2][3] * matr[3][2]) -
-                                matr[1][2] * (matr[2][1] * matr[3][3] - matr[2][3] * matr[3][1]) +
-                                matr[1][3] * (matr[2][1] * matr[3][2] - matr[2][2] * matr[3][1])) -
-                        matr[0][1] *
-                            (matr[1][0] * (matr[2][2] * matr[3][3] - matr[2][3] * matr[3][2]) -
-                                matr[1][2] * (matr[2][0] * matr[3][3] - matr[2][3] * matr[3][0]) +
-                                matr[1][3] * (matr[2][0] * matr[3][2] - matr[2][2] * matr[3][0])) +
-                        matr[0][2] *
-                            (matr[1][0] * (matr[2][1] * matr[3][3] - matr[2][3] * matr[3][1]) -
-                                matr[1][1] * (matr[2][0] * matr[3][3] - matr[2][3] * matr[3][0]) +
-                                matr[1][3] * (matr[2][0] * matr[3][1] - matr[2][1] * matr[3][0])) -
-                        matr[0][3] *
-                            (matr[1][0] * (matr[2][1] * matr[3][2] - matr[2][2] * matr[3][1]) -
-                                matr[1][1] * (matr[2][0] * matr[3][2] - matr[2][2] * matr[3][0]) +
-                                matr[1][2] * (matr[2][0] * matr[3][1] - matr[2][1] * matr[3][0]))
-                    );
+                    return matr[0][0] * (matr[1][1] * (matr[2][2] * matr[3][3] - matr[2][3] * matr[3][2]) - matr[1][2] * (matr[2][1] * matr[3][3] - matr[2][3] * matr[3][1]) + matr[1][3] * (matr[2][1] * matr[3][2] - matr[2][2] * matr[3][1])) - matr[0][1] * (matr[1][0] * (matr[2][2] * matr[3][3] - matr[2][3] * matr[3][2]) - matr[1][2] * (matr[2][0] * matr[3][3] - matr[2][3] * matr[3][0]) + matr[1][3] * (matr[2][0] * matr[3][2] - matr[2][2] * matr[3][0])) + matr[0][2] * (matr[1][0] * (matr[2][1] * matr[3][3] - matr[2][3] * matr[3][1]) - matr[1][1] * (matr[2][0] * matr[3][3] - matr[2][3] * matr[3][0]) + matr[1][3] * (matr[2][0] * matr[3][1] - matr[2][1] * matr[3][0])) - matr[0][3] * (matr[1][0] * (matr[2][1] * matr[3][2] - matr[2][2] * matr[3][1]) - matr[1][1] * (matr[2][0] * matr[3][2] - matr[2][2] * matr[3][0]) + matr[1][2] * (matr[2][0] * matr[3][1] - matr[2][1] * matr[3][0]));
                 } else {
                     let result = 0;
                     for (let i = 0; i < Chalkboard.matr.rows(matr); i++) {
@@ -438,9 +387,7 @@ namespace Chalkboard {
                 const matrv = Chalkboard.matr.mul(matr, v);
                 const max = Chalkboard.stat.max(Chalkboard.matr.toArray(Chalkboard.matr.absolute(matrv)));
                 v = Chalkboard.stat.toMatrix(
-                    Chalkboard.matr.toArray(matrv).map(function (i) {
-                        return i / max;
-                    }),
+                    Chalkboard.matr.toArray(matrv).map((i) => i / max),
                     Chalkboard.matr.rows(matr),
                     1
                 );
@@ -469,13 +416,7 @@ namespace Chalkboard {
             for (let i = 0; i < maxIterations; i++) {
                 const matrv = Chalkboard.matr.mul(matr, v);
                 const max = Chalkboard.stat.max(Chalkboard.matr.toArray(Chalkboard.matr.absolute(matrv)));
-                v = Chalkboard.stat.toMatrix(
-                    Chalkboard.matr.toArray(matrv).map(function (i) {
-                        return i / max;
-                    }),
-                    Chalkboard.matr.rows(matr),
-                    1
-                );
+                v = Chalkboard.stat.toMatrix(Chalkboard.matr.toArray(matrv).map((i) => i / max), Chalkboard.matr.rows(matr), 1 );
             }
             const result = Chalkboard.matr.toArray(v);
             return result;
@@ -678,25 +619,16 @@ namespace Chalkboard {
             if (Chalkboard.matr.isInvertible(matr)) {
                 if (Chalkboard.matr.rows(matr) === 2) {
                     const det = Chalkboard.matr.det(matr);
-                    return Chalkboard.matr.init([matr[1][1] / det, -matr[0][1] / det], [-matr[1][0] / det, matr[0][0] / det]);
+                    return Chalkboard.matr.init(
+                        [matr[1][1] / det, -matr[0][1] / det],
+                        [-matr[1][0] / det, matr[0][0] / det]
+                    );
                 } else if (Chalkboard.matr.rows(matr) === 3) {
                     const det = Chalkboard.matr.det(matr);
                     return Chalkboard.matr.init(
-                        [
-                            (matr[1][1] * matr[2][2] - matr[1][2] * matr[2][1]) / det,
-                            (matr[0][2] * matr[2][1] - matr[0][1] * matr[2][2]) / det,
-                            (matr[0][1] * matr[1][2] - matr[0][2] * matr[1][1]) / det
-                        ],
-                        [
-                            (matr[1][2] * matr[2][0] - matr[1][0] * matr[2][2]) / det,
-                            (matr[0][0] * matr[2][2] - matr[0][2] * matr[2][0]) / det,
-                            (matr[0][2] * matr[1][0] - matr[0][0] * matr[1][2]) / det
-                        ],
-                        [
-                            (matr[1][0] * matr[2][1] - matr[1][1] * matr[2][0]) / det,
-                            (matr[0][1] * matr[2][0] - matr[0][0] * matr[2][1]) / det,
-                            (matr[0][0] * matr[1][1] - matr[0][1] * matr[1][0]) / det
-                        ]
+                        [(matr[1][1] * matr[2][2] - matr[1][2] * matr[2][1]) / det, (matr[0][2] * matr[2][1] - matr[0][1] * matr[2][2]) / det, (matr[0][1] * matr[1][2] - matr[0][2] * matr[1][1]) / det],
+                        [(matr[1][2] * matr[2][0] - matr[1][0] * matr[2][2]) / det, (matr[0][0] * matr[2][2] - matr[0][2] * matr[2][0]) / det, (matr[0][2] * matr[1][0] - matr[0][0] * matr[1][2]) / det],
+                        [(matr[1][0] * matr[2][1] - matr[1][1] * matr[2][0]) / det, (matr[0][1] * matr[2][0] - matr[0][0] * matr[2][1]) / det, (matr[0][0] * matr[1][1] - matr[0][1] * matr[1][0]) / det]
                     );
                 } else if (Chalkboard.matr.rows(matr) === 4) {
                     const det = Chalkboard.matr.det(matr);
@@ -713,30 +645,10 @@ namespace Chalkboard {
                         adj10 = matr[2][1] * matr[3][3] - matr[2][3] * matr[3][1],
                         adj11 = matr[2][2] * matr[3][3] - matr[2][3] * matr[3][2];
                     return Chalkboard.matr.init(
-                        [
-                            (matr[1][1] * adj11 - matr[1][2] * adj10 + matr[1][3] * adj09) / det,
-                            (matr[0][2] * adj10 - matr[0][1] * adj11 - matr[0][3] * adj09) / det,
-                            (matr[3][1] * adj05 - matr[3][2] * adj04 + matr[3][3] * adj03) / det,
-                            (matr[2][2] * adj04 - matr[2][1] * adj05 - matr[2][3] * adj03) / det
-                        ],
-                        [
-                            (matr[1][2] * adj08 - matr[1][0] * adj11 - matr[1][3] * adj07) / det,
-                            (matr[0][0] * adj11 - matr[0][2] * adj08 + matr[0][3] * adj07) / det,
-                            (matr[3][2] * adj02 - matr[3][0] * adj05 - matr[3][3] * adj01) / det,
-                            (matr[2][0] * adj05 - matr[2][2] * adj02 + matr[2][3] * adj01) / det
-                        ],
-                        [
-                            (matr[1][0] * adj10 - matr[1][1] * adj08 + matr[1][3] * adj06) / det,
-                            (matr[0][1] * adj08 - matr[0][0] * adj10 - matr[0][3] * adj06) / det,
-                            (matr[3][0] * adj04 - matr[3][1] * adj02 + matr[3][3] * adj00) / det,
-                            (matr[2][1] * adj02 - matr[2][0] * adj04 - matr[2][3] * adj00) / det
-                        ],
-                        [
-                            (matr[1][1] * adj07 - matr[1][0] * adj09 - matr[1][2] * adj06) / det,
-                            (matr[0][0] * adj09 - matr[0][1] * adj07 + matr[0][2] * adj06) / det,
-                            (matr[3][1] * adj01 - matr[3][0] * adj03 - matr[3][2] * adj00) / det,
-                            (matr[2][0] * adj03 - matr[2][1] * adj01 + matr[2][2] * adj00) / det
-                        ]
+                        [(matr[1][1] * adj11 - matr[1][2] * adj10 + matr[1][3] * adj09) / det, (matr[0][2] * adj10 - matr[0][1] * adj11 - matr[0][3] * adj09) / det, (matr[3][1] * adj05 - matr[3][2] * adj04 + matr[3][3] * adj03) / det, (matr[2][2] * adj04 - matr[2][1] * adj05 - matr[2][3] * adj03) / det],
+                        [(matr[1][2] * adj08 - matr[1][0] * adj11 - matr[1][3] * adj07) / det, (matr[0][0] * adj11 - matr[0][2] * adj08 + matr[0][3] * adj07) / det, (matr[3][2] * adj02 - matr[3][0] * adj05 - matr[3][3] * adj01) / det, (matr[2][0] * adj05 - matr[2][2] * adj02 + matr[2][3] * adj01) / det],
+                        [(matr[1][0] * adj10 - matr[1][1] * adj08 + matr[1][3] * adj06) / det, (matr[0][1] * adj08 - matr[0][0] * adj10 - matr[0][3] * adj06) / det, (matr[3][0] * adj04 - matr[3][1] * adj02 + matr[3][3] * adj00) / det, (matr[2][1] * adj02 - matr[2][0] * adj04 - matr[2][3] * adj00) / det],
+                        [(matr[1][1] * adj07 - matr[1][0] * adj09 - matr[1][2] * adj06) / det, (matr[0][0] * adj09 - matr[0][1] * adj07 + matr[0][2] * adj06) / det, (matr[3][1] * adj01 - matr[3][0] * adj03 - matr[3][2] * adj00) / det, (matr[2][0] * adj03 - matr[2][1] * adj01 + matr[2][2] * adj00) / det]
                     );
                 } else {
                     const result = Chalkboard.matr.init();
@@ -793,20 +705,7 @@ namespace Chalkboard {
                 } else if (Chalkboard.matr.isSizeOf(matr, 3)) {
                     return matr[0][1] !== 0 && matr[0][2] !== 0 && matr[1][0] !== 0 && matr[1][2] !== 0 && matr[2][0] !== 0 && matr[2][1] !== 0;
                 } else if (Chalkboard.matr.isSizeOf(matr, 4)) {
-                    return (
-                        matr[0][1] !== 0 &&
-                        matr[0][2] !== 0 &&
-                        matr[0][3] !== 0 &&
-                        matr[1][0] !== 0 &&
-                        matr[1][2] !== 0 &&
-                        matr[1][3] !== 0 &&
-                        matr[2][0] !== 0 &&
-                        matr[2][1] !== 0 &&
-                        matr[2][3] !== 0 &&
-                        matr[3][0] !== 0 &&
-                        matr[3][1] !== 0 &&
-                        matr[3][2] !== 0
-                    );
+                    return matr[0][1] !== 0 && matr[0][2] !== 0 && matr[0][3] !== 0 && matr[1][0] !== 0 && matr[1][2] !== 0 && matr[1][3] !== 0 && matr[2][0] !== 0 && matr[2][1] !== 0 && matr[2][3] !== 0 && matr[3][0] !== 0 && matr[3][1] !== 0 && matr[3][2] !== 0;
                 } else {
                     let score = 0;
                     for (let i = 0; i < Chalkboard.matr.rows(matr); i++) {
@@ -832,36 +731,9 @@ namespace Chalkboard {
                 if (Chalkboard.matr.isSizeOf(matr1, 2)) {
                     return matr1[0][0] === matr2[0][0] && matr1[0][1] === matr2[0][1] && matr1[1][0] === matr2[1][0] && matr1[1][1] === matr2[1][1];
                 } else if (Chalkboard.matr.isSizeOf(matr1, 3)) {
-                    return (
-                        matr1[0][0] === matr2[0][0] &&
-                        matr1[0][1] === matr2[0][1] &&
-                        matr1[0][2] === matr2[0][2] &&
-                        matr1[1][0] === matr2[1][0] &&
-                        matr1[1][1] === matr2[1][1] &&
-                        matr1[1][2] === matr2[1][2] &&
-                        matr1[2][0] === matr2[2][0] &&
-                        matr1[2][1] === matr2[2][1] &&
-                        matr1[2][2] === matr2[2][2]
-                    );
+                    return matr1[0][0] === matr2[0][0] && matr1[0][1] === matr2[0][1] && matr1[0][2] === matr2[0][2] && matr1[1][0] === matr2[1][0] && matr1[1][1] === matr2[1][1] && matr1[1][2] === matr2[1][2] && matr1[2][0] === matr2[2][0] && matr1[2][1] === matr2[2][1] && matr1[2][2] === matr2[2][2];
                 } else if (Chalkboard.matr.isSizeOf(matr1, 4)) {
-                    return (
-                        matr1[0][0] === matr2[0][0] &&
-                        matr1[0][1] === matr2[0][1] &&
-                        matr1[0][2] === matr2[0][2] &&
-                        matr1[0][3] === matr2[0][3] &&
-                        matr1[1][0] === matr2[1][0] &&
-                        matr1[1][1] === matr2[1][1] &&
-                        matr1[1][2] === matr2[1][2] &&
-                        matr1[1][3] === matr2[1][3] &&
-                        matr1[2][0] === matr2[2][0] &&
-                        matr1[2][1] === matr2[2][1] &&
-                        matr1[2][2] === matr2[2][2] &&
-                        matr1[2][3] === matr2[2][3] &&
-                        matr1[3][0] === matr2[3][0] &&
-                        matr1[3][1] === matr2[3][1] &&
-                        matr1[3][2] === matr2[3][2] &&
-                        matr1[3][3] === matr2[3][3]
-                    );
+                    return matr1[0][0] === matr2[0][0] && matr1[0][1] === matr2[0][1] && matr1[0][2] === matr2[0][2] && matr1[0][3] === matr2[0][3] && matr1[1][0] === matr2[1][0] && matr1[1][1] === matr2[1][1] && matr1[1][2] === matr2[1][2] && matr1[1][3] === matr2[1][3] && matr1[2][0] === matr2[2][0] && matr1[2][1] === matr2[2][1] && matr1[2][2] === matr2[2][2] && matr1[2][3] === matr2[2][3] && matr1[3][0] === matr2[3][0] && matr1[3][1] === matr2[3][1] && matr1[3][2] === matr2[3][2] && matr1[3][3] === matr2[3][3];
                 } else {
                     let score = Chalkboard.matr.rows(matr1) * Chalkboard.matr.cols(matr2);
                     for (let i = 0; i < Chalkboard.matr.rows(matr1); i++) {
@@ -1177,7 +1049,10 @@ namespace Chalkboard {
         export const mul = (matr1: ChalkboardMatrix, matr2: ChalkboardMatrix): ChalkboardMatrix => {
             if (Chalkboard.matr.cols(matr1) === Chalkboard.matr.rows(matr2)) {
                 if (Chalkboard.matr.isSizeOf(matr1, 2) && Chalkboard.matr.isSizeOf(matr2, 2, 1)) {
-                    return Chalkboard.matr.init([matr1[0][0] * matr2[0][0] + matr1[0][1] * matr2[1][0]], [matr1[1][0] * matr2[0][0] + matr1[1][1] * matr2[1][0]]);
+                    return Chalkboard.matr.init(
+                        [matr1[0][0] * matr2[0][0] + matr1[0][1] * matr2[1][0]],
+                        [matr1[1][0] * matr2[0][0] + matr1[1][1] * matr2[1][0]]
+                    );
                 } else if (Chalkboard.matr.isSizeOf(matr1, 2) && Chalkboard.matr.isSizeOf(matr2, 2)) {
                     return Chalkboard.matr.init(
                         [matr1[0][0] * matr2[0][0] + matr1[0][1] * matr2[1][0], matr1[0][0] * matr2[0][1] + matr1[0][1] * matr2[1][1]],
@@ -1191,21 +1066,9 @@ namespace Chalkboard {
                     );
                 } else if (Chalkboard.matr.isSizeOf(matr1, 3) && Chalkboard.matr.isSizeOf(matr2, 3)) {
                     return Chalkboard.matr.init(
-                        [
-                            matr1[0][0] * matr2[0][0] + matr1[0][1] * matr2[1][0] + matr1[0][2] * matr2[2][0],
-                            matr1[0][0] * matr2[0][1] + matr1[0][1] * matr2[1][1] + matr1[0][2] * matr2[2][1],
-                            matr1[0][0] * matr2[0][2] + matr1[0][1] * matr2[1][2] + matr1[0][2] * matr2[2][2]
-                        ],
-                        [
-                            matr1[1][0] * matr2[0][0] + matr1[1][1] * matr2[1][0] + matr1[1][2] * matr2[2][0],
-                            matr1[1][0] * matr2[0][1] + matr1[1][1] * matr2[1][1] + matr1[1][2] * matr2[2][1],
-                            matr1[1][0] * matr2[0][2] + matr1[1][1] * matr2[1][2] + matr1[1][2] * matr2[2][2]
-                        ],
-                        [
-                            matr1[2][0] * matr2[0][0] + matr1[2][1] * matr2[1][0] + matr1[2][2] * matr2[2][0],
-                            matr1[2][0] * matr2[0][1] + matr1[2][1] * matr2[1][1] + matr1[2][2] * matr2[2][1],
-                            matr1[2][0] * matr2[0][2] + matr1[2][1] * matr2[1][2] + matr1[2][2] * matr2[2][2]
-                        ]
+                        [matr1[0][0] * matr2[0][0] + matr1[0][1] * matr2[1][0] + matr1[0][2] * matr2[2][0], matr1[0][0] * matr2[0][1] + matr1[0][1] * matr2[1][1] + matr1[0][2] * matr2[2][1], matr1[0][0] * matr2[0][2] + matr1[0][1] * matr2[1][2] + matr1[0][2] * matr2[2][2]],
+                        [matr1[1][0] * matr2[0][0] + matr1[1][1] * matr2[1][0] + matr1[1][2] * matr2[2][0], matr1[1][0] * matr2[0][1] + matr1[1][1] * matr2[1][1] + matr1[1][2] * matr2[2][1], matr1[1][0] * matr2[0][2] + matr1[1][1] * matr2[1][2] + matr1[1][2] * matr2[2][2]],
+                        [matr1[2][0] * matr2[0][0] + matr1[2][1] * matr2[1][0] + matr1[2][2] * matr2[2][0], matr1[2][0] * matr2[0][1] + matr1[2][1] * matr2[1][1] + matr1[2][2] * matr2[2][1], matr1[2][0] * matr2[0][2] + matr1[2][1] * matr2[1][2] + matr1[2][2] * matr2[2][2]]
                     );
                 } else if (Chalkboard.matr.isSizeOf(matr1, 4) && Chalkboard.matr.isSizeOf(matr2, 4, 1)) {
                     return Chalkboard.matr.init(
@@ -1216,30 +1079,10 @@ namespace Chalkboard {
                     );
                 } else if (Chalkboard.matr.isSizeOf(matr1, 4) && Chalkboard.matr.isSizeOf(matr2, 4)) {
                     return Chalkboard.matr.init(
-                        [
-                            matr1[0][0] * matr2[0][0] + matr1[0][1] * matr2[1][0] + matr1[0][2] * matr2[2][0] + matr1[0][3] * matr2[3][0],
-                            matr1[0][0] * matr2[0][1] + matr1[0][1] * matr2[1][1] + matr1[0][2] * matr2[2][1] + matr1[0][3] * matr2[3][1],
-                            matr1[0][0] * matr2[0][2] + matr1[0][1] * matr2[1][2] + matr1[0][2] * matr2[2][2] + matr1[0][3] * matr2[3][2],
-                            matr1[0][0] * matr2[0][3] + matr1[0][1] * matr2[1][3] + matr1[0][2] * matr2[2][3] + matr1[0][3] * matr2[3][3]
-                        ],
-                        [
-                            matr1[1][0] * matr2[0][0] + matr1[1][1] * matr2[1][0] + matr1[1][2] * matr2[2][0] + matr1[1][3] * matr2[3][0],
-                            matr1[1][0] * matr2[0][1] + matr1[1][1] * matr2[1][1] + matr1[1][2] * matr2[2][1] + matr1[1][3] * matr2[3][1],
-                            matr1[1][0] * matr2[0][2] + matr1[1][1] * matr2[1][2] + matr1[1][2] * matr2[2][2] + matr1[1][3] * matr2[3][2],
-                            matr1[1][0] * matr2[0][3] + matr1[1][1] * matr2[1][3] + matr1[1][2] * matr2[2][3] + matr1[1][3] * matr2[3][3]
-                        ],
-                        [
-                            matr1[2][0] * matr2[0][0] + matr1[2][1] * matr2[1][0] + matr1[2][2] * matr2[2][0] + matr1[2][3] * matr2[3][0],
-                            matr1[2][0] * matr2[0][1] + matr1[2][1] * matr2[1][1] + matr1[2][2] * matr2[2][1] + matr1[2][3] * matr2[3][1],
-                            matr1[2][0] * matr2[0][2] + matr1[2][1] * matr2[1][2] + matr1[2][2] * matr2[2][2] + matr1[2][3] * matr2[3][2],
-                            matr1[2][0] * matr2[0][3] + matr1[2][1] * matr2[1][3] + matr1[2][2] * matr2[2][3] + matr1[2][3] * matr2[3][3]
-                        ],
-                        [
-                            matr1[3][0] * matr2[0][0] + matr1[3][1] * matr2[1][0] + matr1[3][2] * matr2[2][0] + matr1[3][3] * matr2[3][0],
-                            matr1[3][0] * matr2[0][1] + matr1[3][1] * matr2[1][1] + matr1[3][2] * matr2[2][1] + matr1[3][3] * matr2[3][1],
-                            matr1[3][0] * matr2[0][2] + matr1[3][1] * matr2[1][2] + matr1[3][2] * matr2[2][2] + matr1[3][3] * matr2[3][2],
-                            matr1[3][0] * matr2[0][3] + matr1[3][1] * matr2[1][3] + matr1[3][2] * matr2[2][3] + matr1[3][3] * matr2[3][3]
-                        ]
+                        [matr1[0][0] * matr2[0][0] + matr1[0][1] * matr2[1][0] + matr1[0][2] * matr2[2][0] + matr1[0][3] * matr2[3][0], matr1[0][0] * matr2[0][1] + matr1[0][1] * matr2[1][1] + matr1[0][2] * matr2[2][1] + matr1[0][3] * matr2[3][1], matr1[0][0] * matr2[0][2] + matr1[0][1] * matr2[1][2] + matr1[0][2] * matr2[2][2] + matr1[0][3] * matr2[3][2], matr1[0][0] * matr2[0][3] + matr1[0][1] * matr2[1][3] + matr1[0][2] * matr2[2][3] + matr1[0][3] * matr2[3][3]],
+                        [matr1[1][0] * matr2[0][0] + matr1[1][1] * matr2[1][0] + matr1[1][2] * matr2[2][0] + matr1[1][3] * matr2[3][0], matr1[1][0] * matr2[0][1] + matr1[1][1] * matr2[1][1] + matr1[1][2] * matr2[2][1] + matr1[1][3] * matr2[3][1], matr1[1][0] * matr2[0][2] + matr1[1][1] * matr2[1][2] + matr1[1][2] * matr2[2][2] + matr1[1][3] * matr2[3][2], matr1[1][0] * matr2[0][3] + matr1[1][1] * matr2[1][3] + matr1[1][2] * matr2[2][3] + matr1[1][3] * matr2[3][3]],
+                        [matr1[2][0] * matr2[0][0] + matr1[2][1] * matr2[1][0] + matr1[2][2] * matr2[2][0] + matr1[2][3] * matr2[3][0], matr1[2][0] * matr2[0][1] + matr1[2][1] * matr2[1][1] + matr1[2][2] * matr2[2][1] + matr1[2][3] * matr2[3][1], matr1[2][0] * matr2[0][2] + matr1[2][1] * matr2[1][2] + matr1[2][2] * matr2[2][2] + matr1[2][3] * matr2[3][2], matr1[2][0] * matr2[0][3] + matr1[2][1] * matr2[1][3] + matr1[2][2] * matr2[2][3] + matr1[2][3] * matr2[3][3]],
+                        [matr1[3][0] * matr2[0][0] + matr1[3][1] * matr2[1][0] + matr1[3][2] * matr2[2][0] + matr1[3][3] * matr2[3][0], matr1[3][0] * matr2[0][1] + matr1[3][1] * matr2[1][1] + matr1[3][2] * matr2[2][1] + matr1[3][3] * matr2[3][1], matr1[3][0] * matr2[0][2] + matr1[3][1] * matr2[1][2] + matr1[3][2] * matr2[2][2] + matr1[3][3] * matr2[3][2], matr1[3][0] * matr2[0][3] + matr1[3][1] * matr2[1][3] + matr1[3][2] * matr2[2][3] + matr1[3][3] * matr2[3][3]]
                     );
                 } else {
                     const result = Chalkboard.matr.init();
@@ -1275,396 +1118,34 @@ namespace Chalkboard {
                 );
             } else if (Chalkboard.matr.isSizeOf(matr1, 3) && Chalkboard.matr.isSizeOf(matr2, 3)) {
                 return Chalkboard.matr.init(
-                    [
-                        matr1[0][0] * matr2[0][0],
-                        matr1[0][0] * matr2[0][1],
-                        matr1[0][0] * matr2[0][2],
-                        matr1[0][1] * matr2[0][0],
-                        matr1[0][1] * matr2[0][1],
-                        matr1[0][1] * matr2[0][2],
-                        matr1[0][2] * matr2[0][0],
-                        matr1[0][2] * matr2[0][1],
-                        matr1[0][2] * matr2[0][2]
-                    ],
-                    [
-                        matr1[0][0] * matr2[1][0],
-                        matr1[0][0] * matr2[1][1],
-                        matr1[0][0] * matr2[1][2],
-                        matr1[0][1] * matr2[1][0],
-                        matr1[0][1] * matr2[1][1],
-                        matr1[0][1] * matr2[1][2],
-                        matr1[0][2] * matr2[1][0],
-                        matr1[0][2] * matr2[1][1],
-                        matr1[0][2] * matr2[1][2]
-                    ],
-                    [
-                        matr1[0][0] * matr2[2][0],
-                        matr1[0][0] * matr2[2][1],
-                        matr1[0][0] * matr2[2][2],
-                        matr1[0][1] * matr2[2][0],
-                        matr1[0][1] * matr2[2][1],
-                        matr1[0][1] * matr2[2][2],
-                        matr1[0][2] * matr2[2][0],
-                        matr1[0][2] * matr2[2][1],
-                        matr1[0][2] * matr2[2][2]
-                    ],
-                    [
-                        matr1[1][0] * matr2[0][0],
-                        matr1[1][0] * matr2[0][1],
-                        matr1[1][0] * matr2[0][2],
-                        matr1[1][1] * matr2[0][0],
-                        matr1[1][1] * matr2[0][1],
-                        matr1[1][1] * matr2[0][2],
-                        matr1[1][2] * matr2[0][0],
-                        matr1[1][2] * matr2[0][1],
-                        matr1[1][2] * matr2[0][2]
-                    ],
-                    [
-                        matr1[1][0] * matr2[1][0],
-                        matr1[1][0] * matr2[1][1],
-                        matr1[1][0] * matr2[1][2],
-                        matr1[1][1] * matr2[1][0],
-                        matr1[1][1] * matr2[1][1],
-                        matr1[1][1] * matr2[1][2],
-                        matr1[1][2] * matr2[1][0],
-                        matr1[1][2] * matr2[1][1],
-                        matr1[1][2] * matr2[1][2]
-                    ],
-                    [
-                        matr1[1][0] * matr2[2][0],
-                        matr1[1][0] * matr2[2][1],
-                        matr1[1][0] * matr2[2][2],
-                        matr1[1][1] * matr2[2][0],
-                        matr1[1][1] * matr2[2][1],
-                        matr1[1][1] * matr2[2][2],
-                        matr1[1][2] * matr2[2][0],
-                        matr1[1][2] * matr2[2][1],
-                        matr1[1][2] * matr2[2][2]
-                    ],
-                    [
-                        matr1[2][0] * matr2[0][0],
-                        matr1[2][0] * matr2[0][1],
-                        matr1[2][0] * matr2[0][2],
-                        matr1[2][1] * matr2[0][0],
-                        matr1[2][1] * matr2[0][1],
-                        matr1[2][1] * matr2[0][2],
-                        matr1[2][2] * matr2[0][0],
-                        matr1[2][2] * matr2[0][1],
-                        matr1[2][2] * matr2[0][2]
-                    ],
-                    [
-                        matr1[2][0] * matr2[1][0],
-                        matr1[2][0] * matr2[1][1],
-                        matr1[2][0] * matr2[1][2],
-                        matr1[2][1] * matr2[1][0],
-                        matr1[2][1] * matr2[1][1],
-                        matr1[2][1] * matr2[1][2],
-                        matr1[2][2] * matr2[1][0],
-                        matr1[2][2] * matr2[1][1],
-                        matr1[2][2] * matr2[1][2]
-                    ],
-                    [
-                        matr1[2][0] * matr2[2][0],
-                        matr1[2][0] * matr2[2][1],
-                        matr1[2][0] * matr2[2][2],
-                        matr1[2][1] * matr2[2][0],
-                        matr1[2][1] * matr2[2][1],
-                        matr1[2][1] * matr2[2][2],
-                        matr1[2][2] * matr2[2][0],
-                        matr1[2][2] * matr2[2][1],
-                        matr1[2][2] * matr2[2][2]
-                    ]
+                    [matr1[0][0] * matr2[0][0], matr1[0][0] * matr2[0][1], matr1[0][0] * matr2[0][2], matr1[0][1] * matr2[0][0], matr1[0][1] * matr2[0][1], matr1[0][1] * matr2[0][2], matr1[0][2] * matr2[0][0], matr1[0][2] * matr2[0][1], matr1[0][2] * matr2[0][2]],
+                    [matr1[0][0] * matr2[1][0], matr1[0][0] * matr2[1][1], matr1[0][0] * matr2[1][2], matr1[0][1] * matr2[1][0], matr1[0][1] * matr2[1][1], matr1[0][1] * matr2[1][2], matr1[0][2] * matr2[1][0], matr1[0][2] * matr2[1][1], matr1[0][2] * matr2[1][2]],
+                    [matr1[0][0] * matr2[2][0], matr1[0][0] * matr2[2][1], matr1[0][0] * matr2[2][2], matr1[0][1] * matr2[2][0], matr1[0][1] * matr2[2][1], matr1[0][1] * matr2[2][2], matr1[0][2] * matr2[2][0], matr1[0][2] * matr2[2][1], matr1[0][2] * matr2[2][2]],
+                    [matr1[1][0] * matr2[0][0], matr1[1][0] * matr2[0][1], matr1[1][0] * matr2[0][2], matr1[1][1] * matr2[0][0], matr1[1][1] * matr2[0][1], matr1[1][1] * matr2[0][2], matr1[1][2] * matr2[0][0], matr1[1][2] * matr2[0][1], matr1[1][2] * matr2[0][2]],
+                    [matr1[1][0] * matr2[1][0], matr1[1][0] * matr2[1][1], matr1[1][0] * matr2[1][2], matr1[1][1] * matr2[1][0], matr1[1][1] * matr2[1][1], matr1[1][1] * matr2[1][2], matr1[1][2] * matr2[1][0], matr1[1][2] * matr2[1][1], matr1[1][2] * matr2[1][2]],
+                    [matr1[1][0] * matr2[2][0], matr1[1][0] * matr2[2][1], matr1[1][0] * matr2[2][2], matr1[1][1] * matr2[2][0], matr1[1][1] * matr2[2][1], matr1[1][1] * matr2[2][2], matr1[1][2] * matr2[2][0], matr1[1][2] * matr2[2][1], matr1[1][2] * matr2[2][2]],
+                    [matr1[2][0] * matr2[0][0], matr1[2][0] * matr2[0][1], matr1[2][0] * matr2[0][2], matr1[2][1] * matr2[0][0], matr1[2][1] * matr2[0][1], matr1[2][1] * matr2[0][2], matr1[2][2] * matr2[0][0], matr1[2][2] * matr2[0][1], matr1[2][2] * matr2[0][2]],
+                    [matr1[2][0] * matr2[1][0], matr1[2][0] * matr2[1][1], matr1[2][0] * matr2[1][2], matr1[2][1] * matr2[1][0], matr1[2][1] * matr2[1][1], matr1[2][1] * matr2[1][2], matr1[2][2] * matr2[1][0], matr1[2][2] * matr2[1][1], matr1[2][2] * matr2[1][2]],
+                    [matr1[2][0] * matr2[2][0], matr1[2][0] * matr2[2][1], matr1[2][0] * matr2[2][2], matr1[2][1] * matr2[2][0], matr1[2][1] * matr2[2][1], matr1[2][1] * matr2[2][2], matr1[2][2] * matr2[2][0], matr1[2][2] * matr2[2][1], matr1[2][2] * matr2[2][2]]
                 );
             } else if (Chalkboard.matr.isSizeOf(matr1, 4) && Chalkboard.matr.isSizeOf(matr2, 4)) {
                 return Chalkboard.matr.init(
-                    [
-                        matr1[0][0] * matr2[0][0],
-                        matr1[0][0] * matr2[0][1],
-                        matr1[0][0] * matr2[0][2],
-                        matr1[0][0] * matr2[0][3],
-                        matr1[0][1] * matr2[0][0],
-                        matr1[0][1] * matr2[0][1],
-                        matr1[0][1] * matr2[0][2],
-                        matr1[0][1] * matr2[0][3],
-                        matr1[0][2] * matr2[0][0],
-                        matr1[0][2] * matr2[0][1],
-                        matr1[0][2] * matr2[0][2],
-                        matr1[0][2] * matr2[0][3],
-                        matr1[0][3] * matr2[0][0],
-                        matr1[0][3] * matr2[0][1],
-                        matr1[0][3] * matr2[0][2],
-                        matr1[0][3] * matr2[0][3]
-                    ],
-                    [
-                        matr1[0][0] * matr2[1][0],
-                        matr1[0][0] * matr2[1][1],
-                        matr1[0][0] * matr2[1][2],
-                        matr1[0][0] * matr2[1][3],
-                        matr1[0][1] * matr2[1][0],
-                        matr1[0][1] * matr2[1][1],
-                        matr1[0][1] * matr2[1][2],
-                        matr1[0][1] * matr2[1][3],
-                        matr1[0][2] * matr2[1][0],
-                        matr1[0][2] * matr2[1][1],
-                        matr1[0][2] * matr2[1][2],
-                        matr1[0][2] * matr2[1][3],
-                        matr1[0][3] * matr2[1][0],
-                        matr1[0][3] * matr2[1][1],
-                        matr1[0][3] * matr2[1][2],
-                        matr1[0][3] * matr2[1][3]
-                    ],
-                    [
-                        matr1[0][0] * matr2[2][0],
-                        matr1[0][0] * matr2[2][1],
-                        matr1[0][0] * matr2[2][2],
-                        matr1[0][0] * matr2[2][3],
-                        matr1[0][1] * matr2[2][0],
-                        matr1[0][1] * matr2[2][1],
-                        matr1[0][1] * matr2[2][2],
-                        matr1[0][1] * matr2[2][3],
-                        matr1[0][2] * matr2[2][0],
-                        matr1[0][2] * matr2[2][1],
-                        matr1[0][2] * matr2[2][2],
-                        matr1[0][2] * matr2[2][3],
-                        matr1[0][3] * matr2[2][0],
-                        matr1[0][3] * matr2[2][1],
-                        matr1[0][3] * matr2[2][2],
-                        matr1[0][3] * matr2[2][3]
-                    ],
-                    [
-                        matr1[0][0] * matr2[3][0],
-                        matr1[0][0] * matr2[3][1],
-                        matr1[0][0] * matr2[3][2],
-                        matr1[0][0] * matr2[3][3],
-                        matr1[0][1] * matr2[3][0],
-                        matr1[0][1] * matr2[3][1],
-                        matr1[0][1] * matr2[3][2],
-                        matr1[0][1] * matr2[3][3],
-                        matr1[0][2] * matr2[3][0],
-                        matr1[0][2] * matr2[3][1],
-                        matr1[0][2] * matr2[3][2],
-                        matr1[0][2] * matr2[3][3],
-                        matr1[0][3] * matr2[3][0],
-                        matr1[0][3] * matr2[3][1],
-                        matr1[0][3] * matr2[3][2],
-                        matr1[0][3] * matr2[3][3]
-                    ],
-                    [
-                        matr1[1][0] * matr2[0][0],
-                        matr1[1][0] * matr2[0][1],
-                        matr1[1][0] * matr2[0][2],
-                        matr1[1][0] * matr2[0][3],
-                        matr1[1][1] * matr2[0][0],
-                        matr1[1][1] * matr2[0][1],
-                        matr1[1][1] * matr2[0][2],
-                        matr1[1][1] * matr2[0][3],
-                        matr1[1][2] * matr2[0][0],
-                        matr1[1][2] * matr2[0][1],
-                        matr1[1][2] * matr2[0][2],
-                        matr1[1][2] * matr2[0][3],
-                        matr1[1][3] * matr2[0][0],
-                        matr1[1][3] * matr2[0][1],
-                        matr1[1][3] * matr2[0][2],
-                        matr1[1][3] * matr2[0][3]
-                    ],
-                    [
-                        matr1[1][0] * matr2[1][0],
-                        matr1[1][0] * matr2[1][1],
-                        matr1[1][0] * matr2[1][2],
-                        matr1[1][0] * matr2[1][3],
-                        matr1[1][1] * matr2[1][0],
-                        matr1[1][1] * matr2[1][1],
-                        matr1[1][1] * matr2[1][2],
-                        matr1[1][1] * matr2[1][3],
-                        matr1[1][2] * matr2[1][0],
-                        matr1[1][2] * matr2[1][1],
-                        matr1[1][2] * matr2[1][2],
-                        matr1[1][2] * matr2[1][3],
-                        matr1[1][3] * matr2[1][0],
-                        matr1[1][3] * matr2[1][1],
-                        matr1[1][3] * matr2[1][2],
-                        matr1[1][3] * matr2[1][3]
-                    ],
-                    [
-                        matr1[1][0] * matr2[2][0],
-                        matr1[1][0] * matr2[2][1],
-                        matr1[1][0] * matr2[2][2],
-                        matr1[1][0] * matr2[2][3],
-                        matr1[1][1] * matr2[2][0],
-                        matr1[1][1] * matr2[2][1],
-                        matr1[1][1] * matr2[2][2],
-                        matr1[1][1] * matr2[2][3],
-                        matr1[1][2] * matr2[2][0],
-                        matr1[1][2] * matr2[2][1],
-                        matr1[1][2] * matr2[2][2],
-                        matr1[1][2] * matr2[2][3],
-                        matr1[1][3] * matr2[2][0],
-                        matr1[1][3] * matr2[2][1],
-                        matr1[1][3] * matr2[2][2],
-                        matr1[1][3] * matr2[2][3]
-                    ],
-                    [
-                        matr1[1][0] * matr2[3][0],
-                        matr1[1][0] * matr2[3][1],
-                        matr1[1][0] * matr2[3][2],
-                        matr1[1][0] * matr2[3][3],
-                        matr1[1][1] * matr2[3][0],
-                        matr1[1][1] * matr2[3][1],
-                        matr1[1][1] * matr2[3][2],
-                        matr1[1][1] * matr2[3][3],
-                        matr1[1][2] * matr2[3][0],
-                        matr1[1][2] * matr2[3][1],
-                        matr1[1][2] * matr2[3][2],
-                        matr1[1][2] * matr2[3][3],
-                        matr1[1][3] * matr2[3][0],
-                        matr1[1][3] * matr2[3][1],
-                        matr1[1][3] * matr2[3][2],
-                        matr1[1][3] * matr2[3][3]
-                    ],
-                    [
-                        matr1[2][0] * matr2[0][0],
-                        matr1[2][0] * matr2[0][1],
-                        matr1[2][0] * matr2[0][2],
-                        matr1[2][0] * matr2[0][3],
-                        matr1[2][1] * matr2[0][0],
-                        matr1[2][1] * matr2[0][1],
-                        matr1[2][1] * matr2[0][2],
-                        matr1[2][1] * matr2[0][3],
-                        matr1[2][2] * matr2[0][0],
-                        matr1[2][2] * matr2[0][1],
-                        matr1[2][2] * matr2[0][2],
-                        matr1[2][2] * matr2[0][3],
-                        matr1[2][3] * matr2[0][0],
-                        matr1[2][3] * matr2[0][1],
-                        matr1[2][3] * matr2[0][2],
-                        matr1[2][3] * matr2[0][3]
-                    ],
-                    [
-                        matr1[2][0] * matr2[1][0],
-                        matr1[2][0] * matr2[1][1],
-                        matr1[2][0] * matr2[1][2],
-                        matr1[2][0] * matr2[1][3],
-                        matr1[2][1] * matr2[1][0],
-                        matr1[2][1] * matr2[1][1],
-                        matr1[2][1] * matr2[1][2],
-                        matr1[2][1] * matr2[1][3],
-                        matr1[2][2] * matr2[1][0],
-                        matr1[2][2] * matr2[1][1],
-                        matr1[2][2] * matr2[1][2],
-                        matr1[2][2] * matr2[1][3],
-                        matr1[2][3] * matr2[1][0],
-                        matr1[2][3] * matr2[1][1],
-                        matr1[2][3] * matr2[1][2],
-                        matr1[2][3] * matr2[1][3]
-                    ],
-                    [
-                        matr1[2][0] * matr2[2][0],
-                        matr1[2][0] * matr2[2][1],
-                        matr1[2][0] * matr2[2][2],
-                        matr1[2][0] * matr2[2][3],
-                        matr1[2][1] * matr2[2][0],
-                        matr1[2][1] * matr2[2][1],
-                        matr1[2][1] * matr2[2][2],
-                        matr1[2][1] * matr2[2][3],
-                        matr1[2][2] * matr2[2][0],
-                        matr1[2][2] * matr2[2][1],
-                        matr1[2][2] * matr2[2][2],
-                        matr1[2][2] * matr2[2][3],
-                        matr1[2][3] * matr2[2][0],
-                        matr1[2][3] * matr2[2][1],
-                        matr1[2][3] * matr2[2][2],
-                        matr1[2][3] * matr2[2][3]
-                    ],
-                    [
-                        matr1[2][0] * matr2[3][0],
-                        matr1[2][0] * matr2[3][1],
-                        matr1[2][0] * matr2[3][2],
-                        matr1[2][0] * matr2[3][3],
-                        matr1[2][1] * matr2[3][0],
-                        matr1[2][1] * matr2[3][1],
-                        matr1[2][1] * matr2[3][2],
-                        matr1[2][1] * matr2[3][3],
-                        matr1[2][2] * matr2[3][0],
-                        matr1[2][2] * matr2[3][1],
-                        matr1[2][2] * matr2[3][2],
-                        matr1[2][2] * matr2[3][3],
-                        matr1[2][3] * matr2[3][0],
-                        matr1[2][3] * matr2[3][1],
-                        matr1[2][3] * matr2[3][2],
-                        matr1[2][3] * matr2[3][3]
-                    ],
-                    [
-                        matr1[3][0] * matr2[0][0],
-                        matr1[3][0] * matr2[0][1],
-                        matr1[3][0] * matr2[0][2],
-                        matr1[3][0] * matr2[0][3],
-                        matr1[3][1] * matr2[0][0],
-                        matr1[3][1] * matr2[0][1],
-                        matr1[3][1] * matr2[0][2],
-                        matr1[3][1] * matr2[0][3],
-                        matr1[3][2] * matr2[0][0],
-                        matr1[3][2] * matr2[0][1],
-                        matr1[3][2] * matr2[0][2],
-                        matr1[3][2] * matr2[0][3],
-                        matr1[3][3] * matr2[0][0],
-                        matr1[3][3] * matr2[0][1],
-                        matr1[3][3] * matr2[0][2],
-                        matr1[3][3] * matr2[0][3]
-                    ],
-                    [
-                        matr1[3][0] * matr2[1][0],
-                        matr1[3][0] * matr2[1][1],
-                        matr1[3][0] * matr2[1][2],
-                        matr1[3][0] * matr2[1][3],
-                        matr1[3][1] * matr2[1][0],
-                        matr1[3][1] * matr2[1][1],
-                        matr1[3][1] * matr2[1][2],
-                        matr1[3][1] * matr2[1][3],
-                        matr1[3][2] * matr2[1][0],
-                        matr1[3][2] * matr2[1][1],
-                        matr1[3][2] * matr2[1][2],
-                        matr1[3][2] * matr2[1][3],
-                        matr1[3][3] * matr2[1][0],
-                        matr1[3][3] * matr2[1][1],
-                        matr1[3][3] * matr2[1][2],
-                        matr1[3][3] * matr2[1][3]
-                    ],
-                    [
-                        matr1[3][0] * matr2[2][0],
-                        matr1[3][0] * matr2[2][1],
-                        matr1[3][0] * matr2[2][2],
-                        matr1[3][0] * matr2[2][3],
-                        matr1[3][1] * matr2[2][0],
-                        matr1[3][1] * matr2[2][1],
-                        matr1[3][1] * matr2[2][2],
-                        matr1[3][1] * matr2[2][3],
-                        matr1[3][2] * matr2[2][0],
-                        matr1[3][2] * matr2[2][1],
-                        matr1[3][2] * matr2[2][2],
-                        matr1[3][2] * matr2[2][3],
-                        matr1[3][3] * matr2[2][0],
-                        matr1[3][3] * matr2[2][1],
-                        matr1[3][3] * matr2[2][2],
-                        matr1[3][3] * matr2[2][3]
-                    ],
-                    [
-                        matr1[3][0] * matr2[3][0],
-                        matr1[3][0] * matr2[3][1],
-                        matr1[3][0] * matr2[3][2],
-                        matr1[3][0] * matr2[3][3],
-                        matr1[3][1] * matr2[3][0],
-                        matr1[3][1] * matr2[3][1],
-                        matr1[3][1] * matr2[3][2],
-                        matr1[3][1] * matr2[3][3],
-                        matr1[3][2] * matr2[3][0],
-                        matr1[3][2] * matr2[3][1],
-                        matr1[3][2] * matr2[3][2],
-                        matr1[3][2] * matr2[3][3],
-                        matr1[3][3] * matr2[3][0],
-                        matr1[3][3] * matr2[3][1],
-                        matr1[3][3] * matr2[3][2],
-                        matr1[3][3] * matr2[3][3]
-                    ]
+                    [matr1[0][0] * matr2[0][0], matr1[0][0] * matr2[0][1], matr1[0][0] * matr2[0][2], matr1[0][0] * matr2[0][3], matr1[0][1] * matr2[0][0], matr1[0][1] * matr2[0][1], matr1[0][1] * matr2[0][2], matr1[0][1] * matr2[0][3], matr1[0][2] * matr2[0][0], matr1[0][2] * matr2[0][1], matr1[0][2] * matr2[0][2], matr1[0][2] * matr2[0][3], matr1[0][3] * matr2[0][0], matr1[0][3] * matr2[0][1], matr1[0][3] * matr2[0][2], matr1[0][3] * matr2[0][3]],
+                    [matr1[0][0] * matr2[1][0], matr1[0][0] * matr2[1][1], matr1[0][0] * matr2[1][2], matr1[0][0] * matr2[1][3], matr1[0][1] * matr2[1][0], matr1[0][1] * matr2[1][1], matr1[0][1] * matr2[1][2], matr1[0][1] * matr2[1][3], matr1[0][2] * matr2[1][0], matr1[0][2] * matr2[1][1], matr1[0][2] * matr2[1][2], matr1[0][2] * matr2[1][3], matr1[0][3] * matr2[1][0], matr1[0][3] * matr2[1][1], matr1[0][3] * matr2[1][2], matr1[0][3] * matr2[1][3]],
+                    [matr1[0][0] * matr2[2][0], matr1[0][0] * matr2[2][1], matr1[0][0] * matr2[2][2], matr1[0][0] * matr2[2][3], matr1[0][1] * matr2[2][0], matr1[0][1] * matr2[2][1], matr1[0][1] * matr2[2][2], matr1[0][1] * matr2[2][3], matr1[0][2] * matr2[2][0], matr1[0][2] * matr2[2][1], matr1[0][2] * matr2[2][2], matr1[0][2] * matr2[2][3], matr1[0][3] * matr2[2][0], matr1[0][3] * matr2[2][1], matr1[0][3] * matr2[2][2], matr1[0][3] * matr2[2][3]],
+                    [matr1[0][0] * matr2[3][0], matr1[0][0] * matr2[3][1], matr1[0][0] * matr2[3][2], matr1[0][0] * matr2[3][3], matr1[0][1] * matr2[3][0], matr1[0][1] * matr2[3][1], matr1[0][1] * matr2[3][2], matr1[0][1] * matr2[3][3], matr1[0][2] * matr2[3][0], matr1[0][2] * matr2[3][1], matr1[0][2] * matr2[3][2], matr1[0][2] * matr2[3][3], matr1[0][3] * matr2[3][0], matr1[0][3] * matr2[3][1], matr1[0][3] * matr2[3][2], matr1[0][3] * matr2[3][3]],
+                    [matr1[1][0] * matr2[0][0], matr1[1][0] * matr2[0][1], matr1[1][0] * matr2[0][2], matr1[1][0] * matr2[0][3], matr1[1][1] * matr2[0][0], matr1[1][1] * matr2[0][1], matr1[1][1] * matr2[0][2], matr1[1][1] * matr2[0][3], matr1[1][2] * matr2[0][0], matr1[1][2] * matr2[0][1], matr1[1][2] * matr2[0][2], matr1[1][2] * matr2[0][3], matr1[1][3] * matr2[0][0], matr1[1][3] * matr2[0][1], matr1[1][3] * matr2[0][2], matr1[1][3] * matr2[0][3]],
+                    [matr1[1][0] * matr2[1][0], matr1[1][0] * matr2[1][1], matr1[1][0] * matr2[1][2], matr1[1][0] * matr2[1][3], matr1[1][1] * matr2[1][0], matr1[1][1] * matr2[1][1], matr1[1][1] * matr2[1][2], matr1[1][1] * matr2[1][3], matr1[1][2] * matr2[1][0], matr1[1][2] * matr2[1][1], matr1[1][2] * matr2[1][2], matr1[1][2] * matr2[1][3], matr1[1][3] * matr2[1][0], matr1[1][3] * matr2[1][1], matr1[1][3] * matr2[1][2], matr1[1][3] * matr2[1][3]],
+                    [matr1[1][0] * matr2[2][0], matr1[1][0] * matr2[2][1], matr1[1][0] * matr2[2][2], matr1[1][0] * matr2[2][3], matr1[1][1] * matr2[2][0], matr1[1][1] * matr2[2][1], matr1[1][1] * matr2[2][2], matr1[1][1] * matr2[2][3], matr1[1][2] * matr2[2][0], matr1[1][2] * matr2[2][1], matr1[1][2] * matr2[2][2], matr1[1][2] * matr2[2][3], matr1[1][3] * matr2[2][0], matr1[1][3] * matr2[2][1], matr1[1][3] * matr2[2][2], matr1[1][3] * matr2[2][3]],
+                    [matr1[1][0] * matr2[3][0], matr1[1][0] * matr2[3][1], matr1[1][0] * matr2[3][2], matr1[1][0] * matr2[3][3], matr1[1][1] * matr2[3][0], matr1[1][1] * matr2[3][1], matr1[1][1] * matr2[3][2], matr1[1][1] * matr2[3][3], matr1[1][2] * matr2[3][0], matr1[1][2] * matr2[3][1], matr1[1][2] * matr2[3][2], matr1[1][2] * matr2[3][3], matr1[1][3] * matr2[3][0], matr1[1][3] * matr2[3][1], matr1[1][3] * matr2[3][2], matr1[1][3] * matr2[3][3]],
+                    [matr1[2][0] * matr2[0][0], matr1[2][0] * matr2[0][1], matr1[2][0] * matr2[0][2], matr1[2][0] * matr2[0][3], matr1[2][1] * matr2[0][0], matr1[2][1] * matr2[0][1], matr1[2][1] * matr2[0][2], matr1[2][1] * matr2[0][3], matr1[2][2] * matr2[0][0], matr1[2][2] * matr2[0][1], matr1[2][2] * matr2[0][2], matr1[2][2] * matr2[0][3], matr1[2][3] * matr2[0][0], matr1[2][3] * matr2[0][1], matr1[2][3] * matr2[0][2], matr1[2][3] * matr2[0][3]],
+                    [matr1[2][0] * matr2[1][0], matr1[2][0] * matr2[1][1], matr1[2][0] * matr2[1][2], matr1[2][0] * matr2[1][3], matr1[2][1] * matr2[1][0], matr1[2][1] * matr2[1][1], matr1[2][1] * matr2[1][2], matr1[2][1] * matr2[1][3], matr1[2][2] * matr2[1][0], matr1[2][2] * matr2[1][1], matr1[2][2] * matr2[1][2], matr1[2][2] * matr2[1][3], matr1[2][3] * matr2[1][0], matr1[2][3] * matr2[1][1], matr1[2][3] * matr2[1][2], matr1[2][3] * matr2[1][3]],
+                    [matr1[2][0] * matr2[2][0], matr1[2][0] * matr2[2][1], matr1[2][0] * matr2[2][2], matr1[2][0] * matr2[2][3], matr1[2][1] * matr2[2][0], matr1[2][1] * matr2[2][1], matr1[2][1] * matr2[2][2], matr1[2][1] * matr2[2][3], matr1[2][2] * matr2[2][0], matr1[2][2] * matr2[2][1], matr1[2][2] * matr2[2][2], matr1[2][2] * matr2[2][3], matr1[2][3] * matr2[2][0], matr1[2][3] * matr2[2][1], matr1[2][3] * matr2[2][2], matr1[2][3] * matr2[2][3]],
+                    [matr1[2][0] * matr2[3][0], matr1[2][0] * matr2[3][1], matr1[2][0] * matr2[3][2], matr1[2][0] * matr2[3][3], matr1[2][1] * matr2[3][0], matr1[2][1] * matr2[3][1], matr1[2][1] * matr2[3][2], matr1[2][1] * matr2[3][3], matr1[2][2] * matr2[3][0], matr1[2][2] * matr2[3][1], matr1[2][2] * matr2[3][2], matr1[2][2] * matr2[3][3], matr1[2][3] * matr2[3][0], matr1[2][3] * matr2[3][1], matr1[2][3] * matr2[3][2], matr1[2][3] * matr2[3][3]],
+                    [matr1[3][0] * matr2[0][0], matr1[3][0] * matr2[0][1], matr1[3][0] * matr2[0][2], matr1[3][0] * matr2[0][3], matr1[3][1] * matr2[0][0], matr1[3][1] * matr2[0][1], matr1[3][1] * matr2[0][2], matr1[3][1] * matr2[0][3], matr1[3][2] * matr2[0][0], matr1[3][2] * matr2[0][1], matr1[3][2] * matr2[0][2], matr1[3][2] * matr2[0][3], matr1[3][3] * matr2[0][0], matr1[3][3] * matr2[0][1], matr1[3][3] * matr2[0][2], matr1[3][3] * matr2[0][3]],
+                    [matr1[3][0] * matr2[1][0], matr1[3][0] * matr2[1][1], matr1[3][0] * matr2[1][2], matr1[3][0] * matr2[1][3], matr1[3][1] * matr2[1][0], matr1[3][1] * matr2[1][1], matr1[3][1] * matr2[1][2], matr1[3][1] * matr2[1][3], matr1[3][2] * matr2[1][0], matr1[3][2] * matr2[1][1], matr1[3][2] * matr2[1][2], matr1[3][2] * matr2[1][3], matr1[3][3] * matr2[1][0], matr1[3][3] * matr2[1][1], matr1[3][3] * matr2[1][2], matr1[3][3] * matr2[1][3]],
+                    [matr1[3][0] * matr2[2][0], matr1[3][0] * matr2[2][1], matr1[3][0] * matr2[2][2], matr1[3][0] * matr2[2][3], matr1[3][1] * matr2[2][0], matr1[3][1] * matr2[2][1], matr1[3][1] * matr2[2][2], matr1[3][1] * matr2[2][3], matr1[3][2] * matr2[2][0], matr1[3][2] * matr2[2][1], matr1[3][2] * matr2[2][2], matr1[3][2] * matr2[2][3], matr1[3][3] * matr2[2][0], matr1[3][3] * matr2[2][1], matr1[3][3] * matr2[2][2], matr1[3][3] * matr2[2][3]],
+                    [matr1[3][0] * matr2[3][0], matr1[3][0] * matr2[3][1], matr1[3][0] * matr2[3][2], matr1[3][0] * matr2[3][3], matr1[3][1] * matr2[3][0], matr1[3][1] * matr2[3][1], matr1[3][1] * matr2[3][2], matr1[3][1] * matr2[3][3], matr1[3][2] * matr2[3][0], matr1[3][2] * matr2[3][1], matr1[3][2] * matr2[3][2], matr1[3][2] * matr2[3][3], matr1[3][3] * matr2[3][0], matr1[3][3] * matr2[3][1], matr1[3][3] * matr2[3][2], matr1[3][3] * matr2[3][3]]
                 );
             } else {
                 const result = Chalkboard.matr.init();
@@ -1726,12 +1207,7 @@ namespace Chalkboard {
             } else if (Chalkboard.matr.isSizeOf(matr, 3)) {
                 return Chalkboard.matr.init([-matr[0][0], -matr[0][1], -matr[0][2]], [-matr[1][0], -matr[1][1], -matr[1][2]], [-matr[2][0], -matr[2][1], -matr[2][2]]);
             } else if (Chalkboard.matr.isSizeOf(matr, 4)) {
-                return Chalkboard.matr.init(
-                    [-matr[0][0], -matr[0][1], -matr[0][2], -matr[0][3]],
-                    [-matr[1][0], -matr[1][1], -matr[1][2], -matr[1][3]],
-                    [-matr[2][0], -matr[2][1], -matr[2][2], -matr[2][3]],
-                    [-matr[3][0], -matr[3][1], -matr[3][2], -matr[3][3]]
-                );
+                return Chalkboard.matr.init([-matr[0][0], -matr[0][1], -matr[0][2], -matr[0][3]], [-matr[1][0], -matr[1][1], -matr[1][2], -matr[1][3]], [-matr[2][0], -matr[2][1], -matr[2][2], -matr[2][3]], [-matr[3][0], -matr[3][1], -matr[3][2], -matr[3][3]]);
             } else {
                 const result = Chalkboard.matr.init();
                 for (let i = 0; i < Chalkboard.matr.rows(matr); i++) {
@@ -1755,36 +1231,9 @@ namespace Chalkboard {
             if (Chalkboard.matr.isSizeOf(matr, 2) && p === 2 && q === 2) {
                 return Chalkboard.real.sqrt(matr[0][0] * matr[0][0] + matr[0][1] * matr[0][1] + matr[1][0] * matr[1][0] + matr[1][1] * matr[1][1]);
             } else if (Chalkboard.matr.isSizeOf(matr, 3) && p === 2 && q === 2) {
-                return Chalkboard.real.sqrt(
-                    matr[0][0] * matr[0][0] +
-                        matr[0][1] * matr[0][1] +
-                        matr[0][2] * matr[0][2] +
-                        matr[1][0] * matr[1][0] +
-                        matr[1][1] * matr[1][1] +
-                        matr[1][2] * matr[1][2] +
-                        matr[2][0] * matr[2][0] +
-                        matr[2][1] * matr[2][1] +
-                        matr[2][2] * matr[2][2]
-                );
+                return Chalkboard.real.sqrt(matr[0][0] * matr[0][0] + matr[0][1] * matr[0][1] + matr[0][2] * matr[0][2] + matr[1][0] * matr[1][0] + matr[1][1] * matr[1][1] + matr[1][2] * matr[1][2] + matr[2][0] * matr[2][0] + matr[2][1] * matr[2][1] + matr[2][2] * matr[2][2]);
             } else if (Chalkboard.matr.isSizeOf(matr, 4) && p === 2 && q === 2) {
-                return Chalkboard.real.sqrt(
-                    matr[0][0] * matr[0][0] +
-                        matr[0][1] * matr[0][1] +
-                        matr[0][2] * matr[0][2] +
-                        matr[0][3] * matr[0][3] +
-                        matr[1][0] * matr[1][0] +
-                        matr[1][1] * matr[1][1] +
-                        matr[1][2] * matr[1][2] +
-                        matr[1][3] * matr[1][3] +
-                        matr[2][0] * matr[2][0] +
-                        matr[2][1] * matr[2][1] +
-                        matr[2][2] * matr[2][2] +
-                        matr[2][3] * matr[2][3] +
-                        matr[3][0] * matr[3][0] +
-                        matr[3][1] * matr[3][1] +
-                        matr[3][2] * matr[3][2] +
-                        matr[3][3] * matr[3][3]
-                );
+                return Chalkboard.real.sqrt(matr[0][0] * matr[0][0] + matr[0][1] * matr[0][1] + matr[0][2] * matr[0][2] + matr[0][3] * matr[0][3] + matr[1][0] * matr[1][0] + matr[1][1] * matr[1][1] + matr[1][2] * matr[1][2] + matr[1][3] * matr[1][3] + matr[2][0] * matr[2][0] + matr[2][1] * matr[2][1] + matr[2][2] * matr[2][2] + matr[2][3] * matr[2][3] + matr[3][0] * matr[3][0] + matr[3][1] * matr[3][1] + matr[3][2] * matr[3][2] + matr[3][3] * matr[3][3]);
             } else {
                 let result = 0;
                 for (let i = 0; i < Chalkboard.matr.rows(matr); i++) {
@@ -1819,30 +1268,10 @@ namespace Chalkboard {
                 );
             } else if (Chalkboard.matr.isSizeOf(matr, 4)) {
                 return Chalkboard.matr.init(
-                    [
-                        matr[0][0] / Chalkboard.matr.norm(matr, p, q),
-                        matr[0][1] / Chalkboard.matr.norm(matr, p, q),
-                        matr[0][2] / Chalkboard.matr.norm(matr, p, q),
-                        matr[0][3] / Chalkboard.matr.norm(matr, p, q)
-                    ],
-                    [
-                        matr[1][0] / Chalkboard.matr.norm(matr, p, q),
-                        matr[1][1] / Chalkboard.matr.norm(matr, p, q),
-                        matr[1][2] / Chalkboard.matr.norm(matr, p, q),
-                        matr[1][3] / Chalkboard.matr.norm(matr, p, q)
-                    ],
-                    [
-                        matr[2][0] / Chalkboard.matr.norm(matr, p, q),
-                        matr[2][1] / Chalkboard.matr.norm(matr, p, q),
-                        matr[2][2] / Chalkboard.matr.norm(matr, p, q),
-                        matr[2][3] / Chalkboard.matr.norm(matr, p, q)
-                    ],
-                    [
-                        matr[3][0] / Chalkboard.matr.norm(matr, p, q),
-                        matr[3][1] / Chalkboard.matr.norm(matr, p, q),
-                        matr[3][2] / Chalkboard.matr.norm(matr, p, q),
-                        matr[3][3] / Chalkboard.matr.norm(matr, p, q)
-                    ]
+                    [matr[0][0] / Chalkboard.matr.norm(matr, p, q), matr[0][1] / Chalkboard.matr.norm(matr, p, q), matr[0][2] / Chalkboard.matr.norm(matr, p, q), matr[0][3] / Chalkboard.matr.norm(matr, p, q)],
+                    [matr[1][0] / Chalkboard.matr.norm(matr, p, q), matr[1][1] / Chalkboard.matr.norm(matr, p, q), matr[1][2] / Chalkboard.matr.norm(matr, p, q), matr[1][3] / Chalkboard.matr.norm(matr, p, q)],
+                    [matr[2][0] / Chalkboard.matr.norm(matr, p, q), matr[2][1] / Chalkboard.matr.norm(matr, p, q), matr[2][2] / Chalkboard.matr.norm(matr, p, q), matr[2][3] / Chalkboard.matr.norm(matr, p, q)],
+                    [matr[3][0] / Chalkboard.matr.norm(matr, p, q), matr[3][1] / Chalkboard.matr.norm(matr, p, q), matr[3][2] / Chalkboard.matr.norm(matr, p, q), matr[3][3] / Chalkboard.matr.norm(matr, p, q)]
                 );
             } else {
                 const result = Chalkboard.matr.init();
@@ -1867,36 +1296,9 @@ namespace Chalkboard {
             if (Chalkboard.matr.isSizeOf(matr, 2) && p === 2 && q === 2) {
                 return matr[0][0] * matr[0][0] + matr[0][1] * matr[0][1] + matr[1][0] * matr[1][0] + matr[1][1] * matr[1][1];
             } else if (Chalkboard.matr.isSizeOf(matr, 3) && p === 2 && q === 2) {
-                return (
-                    matr[0][0] * matr[0][0] +
-                    matr[0][1] * matr[0][1] +
-                    matr[0][2] * matr[0][2] +
-                    matr[1][0] * matr[1][0] +
-                    matr[1][1] * matr[1][1] +
-                    matr[1][2] * matr[1][2] +
-                    matr[2][0] * matr[2][0] +
-                    matr[2][1] * matr[2][1] +
-                    matr[2][2] * matr[2][2]
-                );
+                return matr[0][0] * matr[0][0] + matr[0][1] * matr[0][1] + matr[0][2] * matr[0][2] + matr[1][0] * matr[1][0] + matr[1][1] * matr[1][1] + matr[1][2] * matr[1][2] + matr[2][0] * matr[2][0] + matr[2][1] * matr[2][1] + matr[2][2] * matr[2][2];
             } else if (Chalkboard.matr.isSizeOf(matr, 4) && p === 2 && q === 2) {
-                return (
-                    matr[0][0] * matr[0][0] +
-                    matr[0][1] * matr[0][1] +
-                    matr[0][2] * matr[0][2] +
-                    matr[0][3] * matr[0][3] +
-                    matr[1][0] * matr[1][0] +
-                    matr[1][1] * matr[1][1] +
-                    matr[1][2] * matr[1][2] +
-                    matr[1][3] * matr[1][3] +
-                    matr[2][0] * matr[2][0] +
-                    matr[2][1] * matr[2][1] +
-                    matr[2][2] * matr[2][2] +
-                    matr[2][3] * matr[2][3] +
-                    matr[3][0] * matr[3][0] +
-                    matr[3][1] * matr[3][1] +
-                    matr[3][2] * matr[3][2] +
-                    matr[3][3] * matr[3][3]
-                );
+                return matr[0][0] * matr[0][0] + matr[0][1] * matr[0][1] + matr[0][2] * matr[0][2] + matr[0][3] * matr[0][3] + matr[1][0] * matr[1][0] + matr[1][1] * matr[1][1] + matr[1][2] * matr[1][2] + matr[1][3] * matr[1][3] + matr[2][0] * matr[2][0] + matr[2][1] * matr[2][1] + matr[2][2] * matr[2][2] + matr[2][3] * matr[2][3] + matr[3][0] * matr[3][0] + matr[3][1] * matr[3][1] + matr[3][2] * matr[3][2] + matr[3][3] * matr[3][3];
             } else {
                 let result = 0;
                 for (let i = 0; i < Chalkboard.matr.rows(matr); i++) {
@@ -1916,19 +1318,9 @@ namespace Chalkboard {
          * @returns {ChalkboardMatrix}
          */
         export const nullspace = (matr: ChalkboardMatrix): ChalkboardMatrix => {
-            const augmented = matr.map(function (row) {
-                return row.slice().concat(Array(Chalkboard.matr.rows(matr)).fill(0));
-            });
+            const augmented = matr.map((row) => row.slice().concat(Array(Chalkboard.matr.rows(matr)).fill(0)));
             const rowEchelonForm = Chalkboard.matr.Gaussian(augmented);
-            return rowEchelonForm
-                .filter(function (row: number[]) {
-                    return row.slice(0, Chalkboard.matr.rows(matr)).every(function (element) {
-                        return element === 0;
-                    });
-                })
-                .map(function (row: number[]) {
-                    return row.slice(Chalkboard.matr.rows(matr));
-                });
+            return rowEchelonForm.filter((row: number[]) => row.slice(0, Chalkboard.matr.rows(matr)).every((element) => element === 0)).map((row: number[]) => row.slice(Chalkboard.matr.rows(matr)));
         };
 
         /**
@@ -1943,30 +1335,9 @@ namespace Chalkboard {
                 } else if (Chalkboard.matr.rows(matr) === 2) {
                     return matr[0][0] * matr[1][1] + matr[0][1] * matr[1][0];
                 } else if (Chalkboard.matr.rows(matr) === 3) {
-                    return (
-                        matr[0][0] * (matr[1][1] * matr[2][2] + matr[1][2] * matr[2][1]) +
-                        matr[0][1] * (matr[1][0] * matr[2][2] + matr[1][2] * matr[2][0]) +
-                        matr[0][2] * (matr[1][0] * matr[2][1] + matr[1][1] * matr[2][0])
-                    );
+                    return matr[0][0] * (matr[1][1] * matr[2][2] + matr[1][2] * matr[2][1]) + matr[0][1] * (matr[1][0] * matr[2][2] + matr[1][2] * matr[2][0]) + matr[0][2] * (matr[1][0] * matr[2][1] + matr[1][1] * matr[2][0]);
                 } else if (Chalkboard.matr.rows(matr) === 4) {
-                    return (
-                        matr[0][0] *
-                            (matr[1][1] * (matr[2][2] * matr[3][3] + matr[2][3] * matr[3][2]) +
-                                matr[1][2] * (matr[2][1] * matr[3][3] + matr[2][3] * matr[3][1]) +
-                                matr[1][3] * (matr[2][1] * matr[3][2] + matr[2][2] * matr[3][1])) +
-                        matr[0][1] *
-                            (matr[1][0] * (matr[2][2] * matr[3][3] + matr[2][3] * matr[3][2]) +
-                                matr[1][2] * (matr[2][0] * matr[3][3] + matr[2][3] * matr[3][0]) +
-                                matr[1][3] * (matr[2][0] * matr[3][2] + matr[2][2] * matr[3][0])) +
-                        matr[0][2] *
-                            (matr[1][0] * (matr[2][1] * matr[3][3] + matr[2][3] * matr[3][1]) +
-                                matr[1][1] * (matr[2][0] * matr[3][3] + matr[2][3] * matr[3][0]) +
-                                matr[1][3] * (matr[2][0] * matr[3][1] + matr[2][1] * matr[3][0])) +
-                        matr[0][3] *
-                            (matr[1][0] * (matr[2][1] * matr[3][2] + matr[2][2] * matr[3][1]) +
-                                matr[1][1] * (matr[2][0] * matr[3][2] + matr[2][2] * matr[3][0]) +
-                                matr[1][2] * (matr[2][0] * matr[3][1] + matr[2][1] * matr[3][0]))
-                    );
+                    return matr[0][0] * (matr[1][1] * (matr[2][2] * matr[3][3] + matr[2][3] * matr[3][2]) + matr[1][2] * (matr[2][1] * matr[3][3] + matr[2][3] * matr[3][1]) + matr[1][3] * (matr[2][1] * matr[3][2] + matr[2][2] * matr[3][1])) + matr[0][1] * (matr[1][0] * (matr[2][2] * matr[3][3] + matr[2][3] * matr[3][2]) + matr[1][2] * (matr[2][0] * matr[3][3] + matr[2][3] * matr[3][0]) + matr[1][3] * (matr[2][0] * matr[3][2] + matr[2][2] * matr[3][0])) + matr[0][2] * (matr[1][0] * (matr[2][1] * matr[3][3] + matr[2][3] * matr[3][1]) + matr[1][1] * (matr[2][0] * matr[3][3] + matr[2][3] * matr[3][0]) + matr[1][3] * (matr[2][0] * matr[3][1] + matr[2][1] * matr[3][0])) + matr[0][3] * (matr[1][0] * (matr[2][1] * matr[3][2] + matr[2][2] * matr[3][1]) + matr[1][1] * (matr[2][0] * matr[3][2] + matr[2][2] * matr[3][0]) + matr[1][2] * (matr[2][0] * matr[3][1] + matr[2][1] * matr[3][0]));
                 } else {
                     let result = 0;
                     for (let i = 0; i < Chalkboard.matr.rows(matr); i++) {
@@ -2119,18 +1490,9 @@ namespace Chalkboard {
             if (rows === 2 && cols === 2) {
                 return Chalkboard.matr.init([Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup)], [Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup)]);
             } else if (rows === 3 && cols === 3) {
-                return Chalkboard.matr.init(
-                    [Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup)],
-                    [Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup)],
-                    [Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup)]
-                );
+                return Chalkboard.matr.init([Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup)], [Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup)], [Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup)]);
             } else if (rows === 4 && cols === 4) {
-                return Chalkboard.matr.init(
-                    [Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup)],
-                    [Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup)],
-                    [Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup)],
-                    [Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup)]
-                );
+                return Chalkboard.matr.init([Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup)], [Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup)], [Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup)], [Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup), Chalkboard.numb.random(inf, sup)]);
             } else {
                 const result = Chalkboard.matr.init();
                 for (let i = 0; i < rows; i++) {
@@ -2149,11 +1511,7 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const rank = (matr: ChalkboardMatrix): number => {
-            return Chalkboard.matr.Gaussian(matr).filter(function (row: number[]) {
-                return row.some(function (element) {
-                    return element !== 0;
-                });
-            }).length;
+            return Chalkboard.matr.Gaussian(matr).filter((row: number[]) => row.some((element) => element !== 0)).length;
         };
 
         /**
@@ -2167,12 +1525,7 @@ namespace Chalkboard {
             } else if (Chalkboard.matr.isSizeOf(matr, 3)) {
                 return Chalkboard.matr.init([1 / matr[0][0], 1 / matr[0][1], 1 / matr[0][2]], [1 / matr[1][0], 1 / matr[1][1], 1 / matr[1][2]], [1 / matr[2][0], 1 / matr[2][1], 1 / matr[2][2]]);
             } else if (Chalkboard.matr.isSizeOf(matr, 4)) {
-                return Chalkboard.matr.init(
-                    [1 / matr[0][0], 1 / matr[0][1], 1 / matr[0][2], 1 / matr[0][3]],
-                    [1 / matr[1][0], 1 / matr[1][1], 1 / matr[1][2], 1 / matr[1][3]],
-                    [1 / matr[2][0], 1 / matr[2][1], 1 / matr[2][2], 1 / matr[2][3]],
-                    [1 / matr[3][0], 1 / matr[3][1], 1 / matr[3][2], 1 / matr[3][3]]
-                );
+                return Chalkboard.matr.init([1 / matr[0][0], 1 / matr[0][1], 1 / matr[0][2], 1 / matr[0][3]], [1 / matr[1][0], 1 / matr[1][1], 1 / matr[1][2], 1 / matr[1][3]], [1 / matr[2][0], 1 / matr[2][1], 1 / matr[2][2], 1 / matr[2][3]], [1 / matr[3][0], 1 / matr[3][1], 1 / matr[3][2], 1 / matr[3][3]]);
             } else {
                 const result = Chalkboard.matr.init();
                 for (let i = 0; i < Chalkboard.matr.rows(matr); i++) {
@@ -2232,18 +1585,9 @@ namespace Chalkboard {
             if (Chalkboard.matr.isSizeOf(matr, 2)) {
                 return Chalkboard.matr.init([Math.round(matr[0][0]), Math.round(matr[0][1])], [Math.round(matr[1][0]), Math.round(matr[1][1])]);
             } else if (Chalkboard.matr.isSizeOf(matr, 3)) {
-                return Chalkboard.matr.init(
-                    [Math.round(matr[0][0]), Math.round(matr[0][1]), Math.round(matr[0][2])],
-                    [Math.round(matr[1][0]), Math.round(matr[1][1]), Math.round(matr[1][2])],
-                    [Math.round(matr[2][0]), Math.round(matr[2][1]), Math.round(matr[2][2])]
-                );
+                return Chalkboard.matr.init([Math.round(matr[0][0]), Math.round(matr[0][1]), Math.round(matr[0][2])], [Math.round(matr[1][0]), Math.round(matr[1][1]), Math.round(matr[1][2])], [Math.round(matr[2][0]), Math.round(matr[2][1]), Math.round(matr[2][2])]);
             } else if (Chalkboard.matr.isSizeOf(matr, 4)) {
-                return Chalkboard.matr.init(
-                    [Math.round(matr[0][0]), Math.round(matr[0][1]), Math.round(matr[0][2]), Math.round(matr[0][3])],
-                    [Math.round(matr[1][0]), Math.round(matr[1][1]), Math.round(matr[1][2]), Math.round(matr[1][3])],
-                    [Math.round(matr[2][0]), Math.round(matr[2][1]), Math.round(matr[2][2]), Math.round(matr[2][3])],
-                    [Math.round(matr[3][0]), Math.round(matr[3][1]), Math.round(matr[3][2]), Math.round(matr[3][3])]
-                );
+                return Chalkboard.matr.init([Math.round(matr[0][0]), Math.round(matr[0][1]), Math.round(matr[0][2]), Math.round(matr[0][3])], [Math.round(matr[1][0]), Math.round(matr[1][1]), Math.round(matr[1][2]), Math.round(matr[1][3])], [Math.round(matr[2][0]), Math.round(matr[2][1]), Math.round(matr[2][2]), Math.round(matr[2][3])], [Math.round(matr[3][0]), Math.round(matr[3][1]), Math.round(matr[3][2]), Math.round(matr[3][3])]);
             } else {
                 const result = Chalkboard.matr.init();
                 for (let i = 0; i < Chalkboard.matr.rows(matr); i++) {
@@ -2271,11 +1615,7 @@ namespace Chalkboard {
          * @returns {ChalkboardMatrix}
          */
         export const rowspace = (matr: ChalkboardMatrix): ChalkboardMatrix => {
-            return Chalkboard.matr.Gaussian(matr).filter(function (row: number[]) {
-                return row.some(function (element) {
-                    return element !== 0;
-                });
-            });
+            return Chalkboard.matr.Gaussian(matr).filter((row: number[]) => row.some((element: number) => element !== 0));
         };
 
         /**
@@ -2310,20 +1650,11 @@ namespace Chalkboard {
             } else if (Chalkboard.matr.isSizeOf(matr, 3, 1)) {
                 return Chalkboard.matr.init([matr[0][0] * num], [matr[1][0] * num], [matr[2][0] * num]);
             } else if (Chalkboard.matr.isSizeOf(matr, 3)) {
-                return Chalkboard.matr.init(
-                    [matr[0][0] * num, matr[0][1] * num, matr[0][2] * num],
-                    [matr[1][0] * num, matr[1][1] * num, matr[1][2] * num],
-                    [matr[2][0] * num, matr[2][1] * num, matr[2][2] * num]
-                );
+                return Chalkboard.matr.init([matr[0][0] * num, matr[0][1] * num, matr[0][2] * num], [matr[1][0] * num, matr[1][1] * num, matr[1][2] * num], [matr[2][0] * num, matr[2][1] * num, matr[2][2] * num]);
             } else if (Chalkboard.matr.isSizeOf(matr, 4, 1)) {
                 return Chalkboard.matr.init([matr[0][0] * num], [matr[1][0] * num], [matr[2][0] * num], [matr[3][0] * num]);
             } else if (Chalkboard.matr.isSizeOf(matr, 4)) {
-                return Chalkboard.matr.init(
-                    [matr[0][0] * num, matr[0][1] * num, matr[0][2] * num, matr[0][3] * num],
-                    [matr[1][0] * num, matr[1][1] * num, matr[1][2] * num, matr[1][3] * num],
-                    [matr[2][0] * num, matr[2][1] * num, matr[2][2] * num, matr[2][3] * num],
-                    [matr[3][0] * num, matr[3][1] * num, matr[3][2] * num, matr[3][3] * num]
-                );
+                return Chalkboard.matr.init([matr[0][0] * num, matr[0][1] * num, matr[0][2] * num, matr[0][3] * num], [matr[1][0] * num, matr[1][1] * num, matr[1][2] * num, matr[1][3] * num], [matr[2][0] * num, matr[2][1] * num, matr[2][2] * num, matr[2][3] * num], [matr[3][0] * num, matr[3][1] * num, matr[3][2] * num, matr[3][3] * num]);
             } else {
                 const result = Chalkboard.matr.init();
                 for (let i = 0; i < Chalkboard.matr.rows(matr); i++) {
@@ -2367,7 +1698,10 @@ namespace Chalkboard {
         export const sub = (matr1: ChalkboardMatrix, matr2: ChalkboardMatrix): ChalkboardMatrix => {
             if (Chalkboard.matr.isSizeEqual(matr1, matr2)) {
                 if (Chalkboard.matr.isSizeOf(matr1, 2)) {
-                    return Chalkboard.matr.init([matr1[0][0] - matr2[0][0], matr1[0][1] - matr2[0][1]], [matr1[1][0] - matr2[1][0], matr1[1][1] - matr2[1][1]]);
+                    return Chalkboard.matr.init(
+                        [matr1[0][0] - matr2[0][0], matr1[0][1] - matr2[0][1]],
+                        [matr1[1][0] - matr2[1][0], matr1[1][1] - matr2[1][1]]
+                    );
                 } else if (Chalkboard.matr.isSizeOf(matr1, 3)) {
                     return Chalkboard.matr.init(
                         [matr1[0][0] - matr2[0][0], matr1[0][1] - matr2[0][1], matr1[0][2] - matr2[0][2]],
@@ -2424,24 +1758,7 @@ namespace Chalkboard {
             } else if (Chalkboard.matr.isSizeOf(matr, 3)) {
                 return [matr[0][0], matr[0][1], matr[0][2], matr[1][0], matr[1][1], matr[1][2], matr[2][0], matr[2][1], matr[2][2]];
             } else if (Chalkboard.matr.isSizeOf(matr, 4)) {
-                return [
-                    matr[0][0],
-                    matr[0][1],
-                    matr[0][2],
-                    matr[0][3],
-                    matr[1][0],
-                    matr[1][1],
-                    matr[1][2],
-                    matr[1][3],
-                    matr[2][0],
-                    matr[2][1],
-                    matr[2][2],
-                    matr[2][3],
-                    matr[3][0],
-                    matr[3][1],
-                    matr[3][2],
-                    matr[3][3]
-                ];
+                return [matr[0][0], matr[0][1], matr[0][2], matr[0][3], matr[1][0], matr[1][1], matr[1][2], matr[1][3], matr[2][0], matr[2][1], matr[2][2], matr[2][3], matr[3][0], matr[3][1], matr[3][2], matr[3][3]];
             } else {
                 const result = [];
                 for (let i = 0; i < Chalkboard.matr.rows(matr); i++) {
@@ -2505,64 +1822,22 @@ namespace Chalkboard {
          */
         export const toString = (matr: ChalkboardMatrix): string => {
             if (Chalkboard.matr.isSizeOf(matr, 2)) {
-                return "[ " + matr[0][0].toString() + " " + matr[0][1].toString() + " ]\n[ " + matr[1][0].toString() + " " + matr[1][1].toString() + " ]";
+                return (
+                    "[ " + matr[0][0].toString() + " " + matr[0][1].toString() +
+                    " ]\n[ " + matr[1][0].toString() + " " + matr[1][1].toString() + " ]"
+                );
             } else if (Chalkboard.matr.isSizeOf(matr, 3)) {
                 return (
-                    "[ " +
-                    matr[0][0].toString() +
-                    " " +
-                    matr[0][1].toString() +
-                    " " +
-                    matr[0][2].toString() +
-                    " ]\n[ " +
-                    matr[1][0].toString() +
-                    " " +
-                    matr[1][1].toString() +
-                    " " +
-                    matr[1][2].toString() +
-                    " ]\n[ " +
-                    matr[2][0].toString() +
-                    " " +
-                    matr[2][1].toString() +
-                    " " +
-                    matr[2][2].toString() +
-                    " ]"
+                    "[ " + matr[0][0].toString() + " " + matr[0][1].toString() + " " + matr[0][2].toString() +
+                    " ]\n[ " + matr[1][0].toString() + " " + matr[1][1].toString() + " " + matr[1][2].toString() +
+                    " ]\n[ " + matr[2][0].toString() + " " + matr[2][1].toString() + " " + matr[2][2].toString() + " ]"
                 );
             } else if (Chalkboard.matr.isSizeOf(matr, 4)) {
                 return (
-                    "[ " +
-                    matr[0][0].toString() +
-                    " " +
-                    matr[0][1].toString() +
-                    " " +
-                    matr[0][2].toString() +
-                    " " +
-                    matr[0][3].toString() +
-                    " ]\n[ " +
-                    matr[1][0].toString() +
-                    " " +
-                    matr[1][1].toString() +
-                    " " +
-                    matr[1][2].toString() +
-                    " " +
-                    matr[1][3].toString() +
-                    " ]\n[ " +
-                    matr[2][0].toString() +
-                    " " +
-                    matr[2][1].toString() +
-                    " " +
-                    matr[2][2].toString() +
-                    " " +
-                    matr[2][3].toString() +
-                    " ]\n[ " +
-                    matr[3][0].toString() +
-                    " " +
-                    matr[3][1].toString() +
-                    " " +
-                    matr[3][2].toString() +
-                    " " +
-                    matr[3][3].toString() +
-                    " ]"
+                    "[ " + matr[0][0].toString() + " " + matr[0][1].toString() + " " + matr[0][2].toString() + " " + matr[0][3].toString() +
+                    " ]\n[ " + matr[1][0].toString() + " " + matr[1][1].toString() + " " + matr[1][2].toString() + " " + matr[1][3].toString() +
+                    " ]\n[ " + matr[2][0].toString() + " " + matr[2][1].toString() + " " + matr[2][2].toString() + " " + matr[2][3].toString() +
+                    " ]\n[ " + matr[3][0].toString() + " " + matr[3][1].toString() + " " + matr[3][2].toString() + " " + matr[3][3].toString() + " ]"
                 );
             } else {
                 let result = "";
@@ -2686,12 +1961,7 @@ namespace Chalkboard {
             } else if (Chalkboard.matr.isSizeOf(matr, 3)) {
                 return Chalkboard.matr.init([matr[0][0], matr[1][0], matr[2][0]], [matr[0][1], matr[1][1], matr[2][1]], [matr[0][2], matr[1][2], matr[2][2]]);
             } else if (Chalkboard.matr.isSizeOf(matr, 4)) {
-                return Chalkboard.matr.init(
-                    [matr[0][0], matr[1][0], matr[2][0], matr[3][0]],
-                    [matr[0][1], matr[1][1], matr[2][1], matr[3][1]],
-                    [matr[0][2], matr[1][2], matr[2][2], matr[3][2]],
-                    [matr[0][3], matr[1][3], matr[2][3], matr[3][3]]
-                );
+                return Chalkboard.matr.init([matr[0][0], matr[1][0], matr[2][0], matr[3][0]], [matr[0][1], matr[1][1], matr[2][1], matr[3][1]], [matr[0][2], matr[1][2], matr[2][2], matr[3][2]], [matr[0][3], matr[1][3], matr[2][3], matr[3][3]]);
             } else {
                 const result = Chalkboard.matr.init();
                 for (let i = 0; i < Chalkboard.matr.cols(matr); i++) {
@@ -2782,12 +2052,7 @@ namespace Chalkboard {
             } else if (size === 3) {
                 return Chalkboard.matr.init([elements[0] || 0, elements[1] || 0, elements[2] || 0], [0, elements[3] || 0, elements[4] || 0], [0, 0, elements[5] || 0]);
             } else if (size === 4) {
-                return Chalkboard.matr.init(
-                    [elements[0] || 0, elements[1] || 0, elements[2] || 0, elements[3] || 0],
-                    [0, elements[4] || 0, elements[5] || 0, elements[6] || 0],
-                    [0, 0, elements[7] || 0, elements[8] || 0],
-                    [0, 0, 0, elements[9] || 0]
-                );
+                return Chalkboard.matr.init([elements[0] || 0, elements[1] || 0, elements[2] || 0, elements[3] || 0], [0, elements[4] || 0, elements[5] || 0, elements[6] || 0], [0, 0, elements[7] || 0, elements[8] || 0], [0, 0, 0, elements[9] || 0]);
             } else {
                 elements = Array.isArray(elements[0]) ? elements[0] : elements;
                 const result = Chalkboard.matr.init();

--- a/src/Chalkboard-numb.ts
+++ b/src/Chalkboard-numb.ts
@@ -18,6 +18,7 @@ namespace Chalkboard {
          * const bernoulliRandom = Chalkboard.numb.Bernoullian();
          */
         export const Bernoullian = (p: number = 0.5): number => {
+            if (typeof p !== "number" || !Number.isFinite(p) || p < 0 || p > 1) throw new Error('Chalkboard.numb.Bernoullian: Parameter "p" must be a finite number between 0 and 1.');
             return Math.random() < p ? 1 : 0;
         };
 
@@ -31,22 +32,13 @@ namespace Chalkboard {
          * const coeff = Chalkboard.numb.binomial(7, 3);
          */
         export const binomial = (n: number, k: number): number => {
-            if (k < 0 || k > n) {
-                return 0;
-            }
-            if (k === 0 || k === n) {
-                return 1;
-            }
-            if (k === 1 || k === n - 1) {
-                return n;
-            }
-            if (n - k < k) {
-                k = n - k;
-            }
+            if (!Number.isInteger(n) || !Number.isInteger(k) || n < 0 || k < 0) throw new Error('Chalkboard.numb.binomial: Parameters "n" and "k" must be non-negative integers.');
+            if (k < 0 || k > n) return 0;
+            if (k === 0 || k === n) return 1;
+            if (k === 1 || k === n - 1) return n;
+            if (n - k < k) k = n - k;
             let result = n;
-            for (let i = 2; i <= k; i++) {
-                result *= (n - i + 1) / i;
-            }
+            for (let i = 2; i <= k; i++) result *= (n - i + 1) / i;
             return Math.round(result);
         };
 
@@ -60,6 +52,8 @@ namespace Chalkboard {
          * const change = Chalkboard.numb.change(1, 2);
          */
         export const change = (initial: number, final: number): number => {
+            if (typeof initial !== "number" || typeof final !== "number" || !Number.isFinite(initial) || !Number.isFinite(final)) throw new Error('Chalkboard.numb.change: Parameters "initial" and "final" must be finite numbers.');
+            if (initial === 0) throw new Error('Chalkboard.numb.change: Parameter "initial" must be non-zero.');
             return (final - initial) / initial;
         };
 
@@ -73,6 +67,7 @@ namespace Chalkboard {
          * const combine = Chalkboard.numb.combination(52, 5);
          */
         export const combination = (n: number, r: number): number => {
+            if (!Number.isInteger(n) || !Number.isInteger(r) || n < 0 || r < 0 || r > n) throw new Error('Chalkboard.numb.combination: Parameters "n" and "r" must be integers with 0 <= r <= n.');
             return Chalkboard.numb.factorial(n) / (Chalkboard.numb.factorial(n - r) * Chalkboard.numb.factorial(r));
         };
 
@@ -82,16 +77,14 @@ namespace Chalkboard {
          * @param {number} sup - Upper bound
          * @returns {number[]}
          * @example
-         * // Returns the array [0, 1, 4, ... , 996, 998, 999]
+         * // Returns the array [4, 6, 8, 9, ... , 996, 998, 999, 1000]
          * const arr = Chalkboard.numb.compositeArr(0, 1000);
          */
         export const compositeArr = (inf: number, sup: number): number[] => {
-            const result = [];
-            for (let i = inf; i <= sup; i++) {
-                if (!Chalkboard.numb.isPrime(i)) {
-                    result.push(i);
-                }
-            }
+            if (!Number.isInteger(inf) || !Number.isInteger(sup)) throw new Error('Chalkboard.numb.compositeArr: Parameters "inf" and "sup" must be integers.');
+            if (inf > sup) throw new Error('Chalkboard.numb.compositeArr: Parameter "inf" must be less than or equal to "sup".');
+            const result: number[] = [];
+            for (let i = inf; i <= sup; i++) if (i > 1 && !Chalkboard.numb.isPrime(i)) result.push(i);
             return result;
         };
 
@@ -105,6 +98,8 @@ namespace Chalkboard {
          * const composites = Chalkboard.numb.compositeCount(0, 1000);
          */
         export const compositeCount = (inf: number, sup: number): number => {
+            if (!Number.isInteger(inf) || !Number.isInteger(sup)) throw new Error('Chalkboard.numb.compositeCount: Parameters "inf" and "sup" must be integers.');
+            if (inf > sup) throw new Error('Chalkboard.numb.compositeCount: Parameter "inf" must be less than or equal to "sup".');
             return Chalkboard.numb.compositeArr(inf, sup).length;
         };
 
@@ -121,7 +116,194 @@ namespace Chalkboard {
          * const n5 = Chalkboard.numb.constrain(-1); // Returns 0
          */
         export const constrain = (num: number, range: [number, number] = [0, 1]): number => {
+            if (typeof num !== "number" || !Number.isFinite(num)) throw new Error('Chalkboard.numb.constrain: Parameter "num" must be a finite number.');
+            if (!Array.isArray(range) || range.length !== 2 || typeof range[0] !== "number" || typeof range[1] !== "number" || !Number.isFinite(range[0]) || !Number.isFinite(range[1]) || range[0] > range[1]) throw new Error('Chalkboard.numb.constrain: Parameter "range" must be an array of two finite numbers [min, max] with min <= max.');
             return Math.max(Math.min(num, range[1]), range[0]);
+        };
+
+        /**
+         * Converts a number from and to various different measurement units.
+         * @param {number | number[]} num - Number or numbers
+         * @param {string} from - Original measurement unit
+         * @param {string} to - Desired measurement unit
+         * @returns {number | number[]}
+         */
+        export const convert = (num: number | number[], from: string, to: string): number | number[] => {
+            if (typeof from !== "string" || typeof to !== "string") throw new Error(`Chalkboard.numb.convert: Parameters "from" and "to" must be strings.`);
+            if (Array.isArray(num)) {
+                for (let i = 0; i < num.length; i++) if (typeof num[i] !== "number" || !Number.isFinite(num[i])) throw new Error(`Chalkboard.numb.convert: Parameter "num[${i}]" must be a finite number.`);
+            } else {
+                if (typeof num !== "number" || !Number.isFinite(num)) throw new Error(`Chalkboard.numb.convert: Parameter "num" must be a finite number.`);
+            }
+            const normalize = (str: string): string => str.trim().replace(/\s+/g, " ");
+            const canonicalize = (str: string): string => normalize(str).replace(/\u00B5/g, "μ");
+            const ALIASES: Record<string, string> = {
+                "NM": "nm", "Nm": "nm", "µm": "μm", "CM": "cm", "Cm": "cm", "M": "m", "KM": "km", "Km": "km", "IN": "in", "In": "in", "FT": "ft", "Ft": "ft", "YD": "yd", "Yd": "yd", "MI": "mi", "Mi": "mi", "NMI": "nmi", "Nmi": "nmi",
+                "M2": "m2", "CM2": "cm2", "MM2": "mm2", "KM2": "km2", "FT2": "ft2", "IN2": "in2", "YD2": "yd2", "MI2": "mi2",
+                "NG": "ng", "µg": "μg", "MG": "mg", "G": "g", "KG": "kg", "Kg": "kg", "LB": "lb", "Lb": "lb",
+                "l": "L", "ml": "mL", "cl": "cL", "dl": "dL", "dal": "daL", "hl": "hL", "kl": "kL", "ul": "uL", "μl": "μL", "µl": "μL", "fl. oz": "fl oz", "fl.oz": "fl oz", "floz": "fl oz", "OZ": "oz", "Oz": "oz",
+                "pa": "Pa", "hpa": "hPa", "kpa": "kPa", "mpa": "MPa", "gpa": "GPa", "ATM": "atm", "Atm": "atm", "Torr": "torr", "mmhg": "mmHg",
+                "NS": "ns", "US": "μs", "Us": "μs", "µS": "μs", "MS": "ms", "Ms": "ms", "HR": "h", "Hr": "h", "HRS": "h", "Hrs": "h", "YR": "yr", "Yr": "yr", "WK": "wk", "Wk": "wk",
+                "c": "C", "°c": "C", "°C": "C", "celsius": "C", "f": "F", "°f": "F", "°F": "F", "fahrenheit": "F", "k": "K", "°k": "K", "°K": "K", "kelvin": "K", "r": "R", "°r": "R", "°R": "R", "rankine": "R"
+            };
+            const LENGTH: Record<string, number> = {
+                "fm": 1e-15, "femtometer": 1e-15, "femtometers": 1e-15,
+                "pm": 1e-12, "picometer": 1e-12, "picometers": 1e-12,
+                "nm": 1e-9, "nanometer": 1e-9, "nanometers": 1e-9,
+                "μm": 1e-6, "um": 1e-6, "micrometer": 1e-6, "micrometers": 1e-6,
+                "mm": 1e-3, "millimeter": 1e-3, "millimeters": 1e-3,
+                "cm": 1e-2, "centimeter": 1e-2, "centimeters": 1e-2,
+                "dm": 1e-1, "decimeter": 1e-1, "decimeters": 1e-1,
+                "m": 1, "meter": 1, "meters": 1,
+                "dam": 1e1, "decameter": 1e1, "decameters": 1e1,
+                "hm": 1e2, "hectometer": 1e2, "hectometers": 1e2,
+                "km": 1e3, "kilometer": 1e3, "kilometers": 1e3,
+                "Mm": 1e6, "megameter": 1e6, "megameters": 1e6,
+                "Gm": 1e9, "gigameter": 1e9, "gigameters": 1e9,
+                "Tm": 1e12, "terameter": 1e12, "terameters": 1e12,
+                "Pm": 1e15, "petameter": 1e15, "petameters": 1e15,
+                "in": 0.0254, "inch": 0.0254, "inches": 0.0254,
+                "ft": 0.3048, "foot": 0.3048, "feet": 0.3048,
+                "yd": 0.9144, "yard": 0.9144, "yards": 0.9144,
+                "mi": 1609.344, "mile": 1609.344, "miles": 1609.344,
+                "nmi": 1852, "nautical mile": 1852, "nautical miles": 1852,
+                "ly": 9.4607e15, "lyr": 9.4607e15, "light year": 9.4607e15, "light years": 9.4607e15
+            };
+            const AREA: Record<string, number> = {
+                "mm²": 1e-6, "mm2": 1e-6, "square millimeter": 1e-6, "square millimeters": 1e-6,
+                "cm²": 1e-4, "cm2": 1e-4, "square centimeter": 1e-4, "square centimeters": 1e-4,
+                "dm²": 1e-2, "dm2": 1e-2, "square decimeter": 1e-2, "square decimeters": 1e-2,
+                "m²": 1, "m2": 1, "square meter": 1, "square meters": 1,
+                "a": 100, "are": 100, "ares": 100,
+                "ha": 1e4, "hectare": 1e4, "hectares": 1e4,
+                "km²": 1e6, "km2": 1e6, "square kilometer": 1e6, "square kilometers": 1e6,
+                "in²": 0.00064516, "in2": 0.00064516, "square inch": 0.00064516, "square inches": 0.00064516,
+                "ft²": 0.09290304, "ft2": 0.09290304, "square foot": 0.09290304, "square feet": 0.09290304,
+                "yd²": 0.83612736, "yd2": 0.83612736, "square yard": 0.83612736, "square yards": 0.83612736,
+                "acre": 4046.8564224, "acres": 4046.8564224,
+                "mi²": 2589988.110336, "mi2": 2589988.110336, "square mile": 2589988.110336, "square miles": 2589988.110336
+            };
+            const MASS: Record<string, number> = {
+                "fg": 1e-15, "femtogram": 1e-15, "femtograms": 1e-15,
+                "pg": 1e-12, "picogram": 1e-12, "picograms": 1e-12,
+                "ng": 1e-9, "nanogram": 1e-9, "nanograms": 1e-9,
+                "μg": 1e-6, "ug": 1e-6, "microgram": 1e-6, "micrograms": 1e-6,
+                "mg": 1e-3, "milligram": 1e-3, "milligrams": 1e-3,
+                "cg": 1e-2, "centigram": 1e-2, "centigrams": 1e-2,
+                "dg": 1e-1, "decigram": 1e-1, "decigrams": 1e-1,
+                "g": 1, "gram": 1, "grams": 1,
+                "dag": 1e1, "decagram": 1e1, "decagrams": 1e1,
+                "hg": 1e2, "hectogram": 1e2, "hectograms": 1e2,
+                "kg": 1e3, "kilogram": 1e3, "kilograms": 1e3,
+                "Mg": 1e6, "megagram": 1e6, "megagrams": 1e6,
+                "Gg": 1e9, "gigagram": 1e9, "gigagrams": 1e9,
+                "Tg": 1e12, "teragram": 1e12, "teragrams": 1e12,
+                "Pg": 1e15, "petagram": 1e15, "petagrams": 1e15,
+                "oz": 28.349523125, "ounce": 28.349523125, "ounces": 28.349523125,
+                "lb": 453.59237, "lbs": 453.59237, "pound": 453.59237, "pounds": 453.59237,
+                "st": 6350.29318, "stone": 6350.29318, "stones": 6350.29318,
+                "tn": 907184.74, "ton": 907184.74, "tons": 907184.74,
+                "t": 1000000, "metric ton": 1000000, "metric tons": 1000000
+            };
+            const VOLUME: Record<string, number> = {
+                "fL": 1e-15, "femtoliter": 1e-15, "femtoliters": 1e-15,
+                "pL": 1e-12, "picoliter": 1e-12, "picoliters": 1e-12,
+                "nL": 1e-9, "nanoliter": 1e-9, "nanoliters": 1e-9,
+                "μL": 1e-6, "uL": 1e-6, "microliter": 1e-6, "microliters": 1e-6,
+                "mL": 1e-3, "milliliter": 1e-3, "milliliters": 1e-3,
+                "cL": 1e-2, "centiliter": 1e-2, "centiliters": 1e-2,
+                "dL": 1e-1, "deciliter": 1e-1, "deciliters": 1e-1,
+                "L": 1, "l": 1, "liter": 1, "liters": 1,
+                "daL": 1e1, "decaliter": 1e1, "decaliters": 1e1,
+                "hL": 1e2, "hectoliter": 1e2, "hectoliters": 1e2,
+                "kL": 1e3, "kiloliter": 1e3, "kiloliters": 1e3,
+                "ML": 1e6, "megaliter": 1e6, "megaliters": 1e6,
+                "GL": 1e9, "gigaliter": 1e9, "gigaliters": 1e9,
+                "TL": 1e12, "teraliter": 1e12, "teraliters": 1e12,
+                "PL": 1e15, "petaliter": 1e15, "petaliters": 1e15,
+                "tsp": 0.00492892159, "teaspoon": 0.00492892159, "teaspoons": 0.00492892159,
+                "tbsp": 0.0147867648, "Tbsp": 0.0147867648, "tablespoon": 0.0147867648, "tablespoons": 0.0147867648,
+                "fl oz": 0.0295735296, "fluid ounce": 0.0295735296, "fluid ounces": 0.0295735296,
+                "cp": 0.2365882365, "cup": 0.2365882365, "cups": 0.2365882365,
+                "pt": 0.473176473, "pint": 0.473176473, "pints": 0.473176473,
+                "qt": 0.946352946, "quart": 0.946352946, "quarts": 0.946352946,
+                "gal": 3.785411784, "gallon": 3.785411784, "gallons": 3.785411784
+            };
+            const PRESSURE: Record<string, number> = {
+                "Pa": 1, "pascal": 1, "pascals": 1,
+                "hPa": 100, "hectopascal": 100, "hectopascals": 100,
+                "kPa": 1000, "kilopascal": 1000, "kilopascals": 1000,
+                "MPa": 1e6, "megapascal": 1e6, "megapascals": 1e6,
+                "GPa": 1e9, "gigapascal": 1e9, "gigapascals": 1e9,
+                "bar": 1e5, "bars": 1e5,
+                "mbar": 100, "millibar": 100, "millibars": 100,
+                "atm": 101325, "atmosphere": 101325, "atmospheres": 101325,
+                "torr": 133.32236842105263,
+                "mmHg": 133.32236842105263, "millimeter of mercury": 133.32236842105263, "millimeters of mercury": 133.32236842105263,
+                "psi": 6894.757293168, "pound per square inch": 6894.757293168, "pounds per square inch": 6894.757293168
+            };
+            const TIME: Record<string, number> = {
+                "ns": 1e-9, "nanosecond": 1e-9, "nanoseconds": 1e-9,
+                "μs": 1e-6, "us": 1e-6, "microsecond": 1e-6, "microseconds": 1e-6,
+                "ms": 1e-3, "millisecond": 1e-3, "milliseconds": 1e-3,
+                "s": 1, "sec": 1, "secs": 1, "second": 1, "seconds": 1,
+                "min": 60, "mins": 60, "minute": 60, "minutes": 60,
+                "h": 3600, "hr": 3600, "hrs": 3600, "hour": 3600, "hours": 3600,
+                "d": 86400, "day": 86400, "days": 86400,
+                "w": 604800, "wk": 604800, "wks": 604800, "week": 604800, "weeks": 604800,
+                "yr": 31557600, "yrs": 31557600, "year": 31557600, "years": 31557600
+            };
+            const TEMPERATURE: Record<string, { a: number; b: number; key: string }> = {
+                "K": { a: 1, b: 0, key: "K" },
+                "C": { a: 1, b: 273.15, key: "C" },
+                "F": { a: 5 / 9, b: 273.15 - (32 * 5) / 9, key: "F" },
+                "R": { a: 5 / 9, b: 0, key: "R" }
+            };
+            const TABLE: Array<[string, Record<string, number>]> = [["length", LENGTH], ["area", AREA], ["mass", MASS], ["volume", VOLUME], ["pressure", PRESSURE], ["time", TIME]];
+            const resolveFactor = (str: string): { category: string; factor: number; key: string } | undefined => {
+                const key = canonicalize(str);
+                const alias = ALIASES[key] ?? ALIASES[key.toLowerCase()];
+                const candidates: string[] = [];
+                candidates.push(key);
+                if (alias) candidates.push(alias);
+                const shouldTryLower = key.length > 2 || key.includes(" ");
+                if (shouldTryLower) candidates.push(key.toLowerCase());
+                const seen = new Set<string>();
+                const uniq = candidates.filter((c) => (seen.has(c) ? false : (seen.add(c), true)));
+                for (const [category, map] of TABLE) {
+                    for (const k of uniq) {
+                        if (Object.prototype.hasOwnProperty.call(map, k)) return { category, factor: map[k], key: k };
+                    }
+                }
+                return undefined;
+            };
+            const resolveTemp = (str: string): { a: number; b: number; key: string } | undefined => {
+                const raw = canonicalize(str);
+                const alias = ALIASES[raw] ?? ALIASES[raw.toLowerCase()];
+                const candidates: string[] = [raw];
+                if (alias) candidates.push(alias);
+                const seen = new Set<string>();
+                const uniq = candidates.filter((c) => (seen.has(c) ? false : (seen.add(c), true)));
+                for (const k of uniq) if (Object.prototype.hasOwnProperty.call(TEMPERATURE, k)) return TEMPERATURE[k];
+                return undefined;
+            };
+            const apply = (fn: (x: number) => number) => (Array.isArray(num) ? num.map(fn) : fn(num));
+            const fromTemp = resolveTemp(from);
+            const toTemp = resolveTemp(to);
+            if (fromTemp || toTemp) {
+                if (!fromTemp) throw new Error(`Chalkboard.numb.convert: Unknown temperature unit: "${from}".`);
+                if (!toTemp) throw new Error(`Chalkboard.numb.convert: Unknown temperature unit: "${to}".`);
+                const toKelvin = (x: number) => fromTemp.a * x + fromTemp.b;
+                const fromKelvin = (k: number) => (k - toTemp.b) / toTemp.a;
+                return apply((x) => fromKelvin(toKelvin(x)));
+            }
+            const fromResolved = resolveFactor(from);
+            const toResolved = resolveFactor(to);
+            if (!fromResolved) throw new Error(`Chalkboard.numb.convert: Unknown unit: "${from}".`);
+            if (!toResolved) throw new Error(`Chalkboard.numb.convert: Unknown unit: "${to}".`);
+            if (fromResolved.category !== toResolved.category) throw new Error(`Chalkboard.numb.convert: Incompatible unit conversion: "${from}" (${fromResolved.category}) -> "${to}" (${toResolved.category}).`);
+            const factor = fromResolved.factor / toResolved.factor;
+            return apply((x) => x * factor);
         };
 
         /**
@@ -133,33 +315,31 @@ namespace Chalkboard {
          * const divisors = Chalkboard.numb.divisors(1000000);
          */
         export const divisors = (num: number): number[] => {
-            const result = [];
-            for (let i = 1; i <= num; i++) {
-                if (num % i === 0) {
-                    result.push(i);
-                }
-            }
+            if (!Number.isInteger(num) || num <= 0) throw new Error('Chalkboard.numb.divisors: Parameter "num" must be a positive integer.');
+            const result: number[] = [];
+            for (let i = 1; i <= num; i++) if (num % i === 0) result.push(i);
             return result;
         };
 
         /**
          * Returns the value of Euler's totient function of a number.
          * @param {number} num - Number greater than 0
-         * @returns {number | undefined}
+         * @returns {number}
          * @example
-         * // Returns 4, the number of divisors of 10
+         * // Returns 4, the number of integers less than or equal to 10 that are coprime to 10
          * const totient = Chalkboard.numb.Euler(10);
          */
-        export const Euler = (num: number): number | undefined => {
-            if (num > 0) {
-                const factors = Chalkboard.numb.factors(num);
-                for (let i = 0; i < factors.length; i++) {
-                    num *= (factors[i] - 1) / factors[i];
-                }
-                return num;
-            } else {
-                return undefined;
+        export const Euler = (num: number): number => {
+            if (!Number.isInteger(num) || num <= 0) throw new Error('Chalkboard.numb.Euler: Parameter "num" must be a positive integer.');
+            const primeFactors = Chalkboard.numb.factors(num);
+            const uniquePrimes: number[] = [];
+            for (let i = 0; i < primeFactors.length; i++) {
+                const p = primeFactors[i];
+                if (uniquePrimes.indexOf(p) === -1) uniquePrimes.push(p);
             }
+            let result = num;
+            for (const p of uniquePrimes) result *= (p - 1) / p;
+            return Math.round(result);
         };
 
         /**
@@ -171,7 +351,10 @@ namespace Chalkboard {
          * const expRandom = Chalkboard.numb.exponential(0.1);
          */
         export const exponential = (l: number = 1): number => {
-            return l <= 0 ? 0 : -Math.log(Math.random()) / l;
+            if (typeof l !== "number" || !Number.isFinite(l)) throw new Error('Chalkboard.numb.exponential: Parameter "l" must be a finite number.');
+            if (l <= 0) throw new Error('Chalkboard.numb.exponential: Parameter "l" must be positive.');
+            const u = 1 - Math.random();
+            return -Math.log(u) / l;
         };
 
         /**
@@ -183,10 +366,9 @@ namespace Chalkboard {
          * const factorial = Chalkboard.numb.factorial(5);
          */
         export const factorial = (num: number): number => {
+            if (!Number.isInteger(num) || num < 0) throw new Error('Chalkboard.numb.factorial: Parameter "num" must be a non-negative integer.');
             let n = 1;
-            for (let i = 1; i <= num; i++) {
-                n *= i;
-            }
+            for (let i = 2; i <= num; i++) n *= i;
             return n;
         };
 
@@ -199,7 +381,13 @@ namespace Chalkboard {
          * const factors = Chalkboard.numb.factors(1000000);
          */
         export const factors = (num: number): number[] => {
-            const result = [];
+            if (!Number.isInteger(num)) throw new Error('Chalkboard.numb.factors: Parameter "num" must be an integer.');
+            if (num === 0) throw new Error('Chalkboard.numb.factors: Parameter "num" must be non-zero.');
+            const result: number[] = [];
+            if (num < 0) {
+                result.push(-1);
+                num = Math.abs(num);
+            }
             while (num % 2 === 0) {
                 result.push(2);
                 num /= 2;
@@ -210,9 +398,7 @@ namespace Chalkboard {
                     num /= i;
                 }
             }
-            if (num > 2) {
-                result.push(num);
-            }
+            if (num > 1) result.push(num);
             return result;
         };
 
@@ -225,28 +411,35 @@ namespace Chalkboard {
          * const fibnum = Chalkboard.numb.Fibonacci(10);
          */
         export const Fibonacci = (num: number): number => {
-            const sequence = [0, 1];
-            if (sequence[num] === undefined) {
-                sequence.push(Chalkboard.numb.Fibonacci(num - 1) + sequence[num - 2]);
+            if (!Number.isInteger(num) || num < 0) throw new Error('Chalkboard.numb.Fibonacci: Parameter "num" must be a non-negative integer.');
+            if (num === 0) return 0;
+            if (num === 1) return 1;
+            let a = 0, b = 1;
+            for (let i = 2; i <= num; i++) {
+                const next = a + b;
+                a = b;
+                b = next;
             }
-            return sequence[num];
+            return b;
         };
 
         /**
-         * Returns a random number from a Gaussian (or normal) distribution.
-         * @param {number} height - Height of distribution
+         * Returns a random number from a Gaussian (normal) distribution.
          * @param {number} mean - Mean of distribution
-         * @param {number} deviation - Standard deviation of distribution
+         * @param {number} deviation - Standard deviation of distribution (σ > 0)
          * @returns {number}
          * @example
          * // Standard Gaussian distribution
-         * const gaussRandom = Chalkboard.numb.Gaussian(1, 0, 1 / Chalkboard.real.sqrt(Chalkboard.PI(2)));
+         * const gaussRandom = Chalkboard.numb.Gaussian(0, 1);
          */
-        export const Gaussian = (height: number, mean: number, deviation: number): number => {
-            const u1 = Math.random(),
-                u2 = Math.random();
-            const random = Chalkboard.real.sqrt(-2 * Chalkboard.real.ln(u1)) * Chalkboard.trig.cos(Chalkboard.PI(2) * u2);
-            return random * height * Chalkboard.real.sqrt(deviation) + mean;
+        export const Gaussian = (mean: number, deviation: number): number => {
+            if (!Number.isFinite(mean) || !Number.isFinite(deviation)) throw new Error('Chalkboard.numb.Gaussian: Parameters "mean" and "deviation" must be finite numbers.');
+            if (deviation <= 0) throw new Error('Chalkboard.numb.Gaussian: Parameter "deviation" must be positive.');
+            let u1 = 0;
+            while (u1 === 0) u1 = Math.random();
+            const u2 = Math.random();
+            const z = Chalkboard.real.sqrt(-2 * Chalkboard.real.ln(u1)) * Chalkboard.trig.cos(Chalkboard.PI(2) * u2);
+            return mean + z * deviation;
         };
 
         /**
@@ -259,42 +452,41 @@ namespace Chalkboard {
          * const gcd = Chalkboard.numb.gcd(68, 119);
          */
         export const gcd = (a: number, b: number): number => {
-            if (b === 0) {
-                return a;
+            if (!Number.isInteger(a) || !Number.isInteger(b)) throw new Error('Chalkboard.numb.gcd: Parameters "a" and "b" must be integers.');
+            a = Math.abs(a);
+            b = Math.abs(b);
+            while (b !== 0) {
+                const t = a % b;
+                a = b;
+                b = t;
             }
-            return Chalkboard.numb.gcd(b, a % b);
+            return a;
         };
 
         /**
          * Returns an even number as a sum of two prime numbers.
          * @param {number} num - Even number
-         * @returns {number[] | undefined}
+         * @returns {[number, number] | undefined}
          * @example
          * // Returns [5, 7]
          * const primes = Chalkboard.numb.Goldbach(12);
          */
         export const Goldbach = (num: number): [number, number] | undefined => {
-            if (num % 2 === 0) {
-                if (num !== 4) {
-                    let a = num / 2,
-                        b = num / 2;
-                    if (a % 2 === 0) {
-                        a--;
-                        b++;
-                    }
-                    while (a >= 3) {
-                        if (Chalkboard.numb.isPrime(a) && Chalkboard.numb.isPrime(b)) {
-                            return [a, b];
-                        }
-                        a -= 2;
-                        b += 2;
-                    }
-                    return undefined;
-                } else {
-                    return [2, 2];
+            if (!Number.isInteger(num) || num < 4 || num % 2 !== 0) throw new Error('Chalkboard.numb.Goldbach: Parameter "num" must be an even integer greater than or equal to 4.');
+            if (num !== 4) {
+                let a = num / 2, b = num / 2;
+                if (a % 2 === 0) {
+                    a--;
+                    b++;
                 }
-            } else {
+                while (a >= 3) {
+                    if (Chalkboard.numb.isPrime(a) && Chalkboard.numb.isPrime(b)) return [a, b];
+                    a -= 2;
+                    b += 2;
+                }
                 return undefined;
+            } else {
+                return [2, 2];
             }
         };
 
@@ -309,6 +501,7 @@ namespace Chalkboard {
          * const approx = Chalkboard.numb.isApproxEqual(0.1 + 0.2, 0.3);
          */
         export const isApproxEqual = (a: number, b: number, precision: number = 0.000001): boolean => {
+            if (typeof a !== "number" || typeof b !== "number" || typeof precision !== "number" || !Number.isFinite(a) || !Number.isFinite(b) || !Number.isFinite(precision) || precision <= 0) throw new Error('Chalkboard.numb.isApproxEqual: Parameters "a", "b", and "precision" must be finite numbers, and "precision" must be positive.');
             return Math.abs(a - b) < precision;
         };
 
@@ -328,12 +521,11 @@ namespace Chalkboard {
          * Chalkboard.numb.isPrime(7);
          */
         export const isPrime = (num: number): boolean => {
-            for (let i = 2; i <= Chalkboard.real.sqrt(num); i++) {
-                if (num % i === 0) {
-                    return false;
-                }
-            }
-            return num > 1;
+            if (typeof num !== "number" || !Number.isInteger(num) || num < 2) return false;
+            if (num === 2) return true;
+            if (num % 2 === 0) return false;
+            for (let i = 3; i * i <= num; i += 2) if (num % i === 0) return false;
+            return true;
         };
 
         /**
@@ -346,7 +538,7 @@ namespace Chalkboard {
          * const no = Chalkboard.numb.isRational(Chalkboard.PI()); // Returns false
          */
         export const isRational = (num: number, tolerance: number = 1e-8): boolean => {
-            if (!isFinite(num)) return false;
+            if (typeof num !== "number" || !Number.isFinite(num) || typeof tolerance !== "number" || !Number.isFinite(tolerance) || tolerance <= 0) return false;
             const mult = num / Chalkboard.PI();
             if (mult !== 0 && Math.abs(Math.round(mult) - mult) < tolerance) {
                 return false;
@@ -398,11 +590,9 @@ namespace Chalkboard {
          * const no = Chalkboard.numb.Kronecker(1, 10); // Returns 0
          */
         export const Kronecker = (a: number, b: number): 1 | 0 => {
-            if (a === b) {
-                return 1;
-            } else {
-                return 0;
-            }
+            if (typeof a !== "number" || typeof b !== "number" || !Number.isFinite(a) || !Number.isFinite(b)) throw new Error('Chalkboard.numb.Kronecker: Parameters "a" and "b" must be finite numbers.');
+            if (a === b) return 1;
+            else return 0;
         };
 
         /**
@@ -415,7 +605,9 @@ namespace Chalkboard {
          * const lcm = Chalkboard.numb.lcm(4, 6);
          */
         export const lcm = (a: number, b: number): number => {
-            return a * (b / Chalkboard.numb.gcd(a, b));
+            if (!Number.isInteger(a) || !Number.isInteger(b)) throw new Error('Chalkboard.numb.lcm: Parameters "a" and "b" must be integers.');
+            if (a === 0 || b === 0) return 0;
+            return Math.abs(a / Chalkboard.numb.gcd(a, b) * b);
         };
 
         /**
@@ -429,6 +621,11 @@ namespace Chalkboard {
          * const map = Chalkboard.numb.map(23, [0, 25], [0, 1]);
          */
         export const map = (num: number, range1: number[], range2: number[]): number => {
+            if (!Array.isArray(range1) || !Array.isArray(range2)) throw new Error('Chalkboard.numb.map: Parameters "range1" and "range2" must be arrays.');
+            if (range1.length !== 2 || range2.length !== 2) throw new Error('Chalkboard.numb.map: Parameters "range1" and "range2" must be arrays of length 2.');
+            if (typeof num !== "number" || !Number.isFinite(num)) throw new Error('Chalkboard.numb.map: Parameter "num" must be a finite number.');
+            if (typeof range1[0] !== "number" || typeof range1[1] !== "number" || !Number.isFinite(range1[0]) || !Number.isFinite(range1[1]) || range1[0] >= range1[1]) throw new Error('Chalkboard.numb.map: Parameter "range1" must be an array of two finite numbers [min, max] with min < max.');
+            if (typeof range2[0] !== "number" || typeof range2[1] !== "number" || !Number.isFinite(range2[0]) || !Number.isFinite(range2[1]) || range2[0] > range2[1]) throw new Error('Chalkboard.numb.map: Parameter "range2" must be an array of two finite numbers [min, max] with min <= max.');
             return range2[0] + (range2[1] - range2[0]) * ((num - range1[0]) / (range1[1] - range1[0]));
         };
 
@@ -442,6 +639,8 @@ namespace Chalkboard {
          * const mod = Chalkboard.numb.mod(5, -3);
          */
         export const mod = (a: number, b: number): number => {
+            if (typeof a !== "number" || typeof b !== "number" || !Number.isFinite(a) || !Number.isFinite(b)) throw new Error('Chalkboard.numb.mod: Parameters "a" and "b" must be finite numbers.');
+            if (b === 0) throw new Error('Chalkboard.numb.mod: Parameter "b" must be non-zero.');
             return ((a % b) + b) % b;
         };
 
@@ -456,10 +655,11 @@ namespace Chalkboard {
          * const mul = Chalkboard.numb.mul((n) => n + 1, 0, 5);
          */
         export const mul = (formula: (n: number) => number, inf: number, sup: number): number => {
+            if (typeof formula !== "function") throw new Error('Chalkboard.numb.mul: Parameter "formula" must be a function.');
+            if (!Number.isInteger(inf) || !Number.isInteger(sup)) throw new Error('Chalkboard.numb.mul: Parameters "inf" and "sup" must be integers.');
+            if (inf > sup) throw new Error('Chalkboard.numb.mul: Parameter "inf" must be less than or equal to "sup".');
             let result = 1;
-            for (let i = inf; i <= sup; i++) {
-                result *= formula(i);
-            }
+            for (let i = inf; i <= sup; i++) result *= formula(i);
             return result;
         };
 
@@ -472,10 +672,11 @@ namespace Chalkboard {
          * const prime = Chalkboard.numb.nextPrime(523);
          */
         export const nextPrime = (num: number): number => {
-            let result = num + 1;
-            while (!Chalkboard.numb.isPrime(result)) {
-                result++;
-            }
+            if (!Number.isFinite(num)) throw new Error('Chalkboard.numb.nextPrime: Parameter "num" must be finite.');
+            let result = Math.floor(num) + 1;
+            if (result <= 2) return 2;
+            if (result % 2 === 0) result++;
+            while (!Chalkboard.numb.isPrime(result)) result += 2;
             return result;
         };
 
@@ -489,6 +690,7 @@ namespace Chalkboard {
          * const permute = Chalkboard.numb.permutation(4, 4);
          */
         export const permutation = (n: number, r: number): number => {
+            if (!Number.isInteger(n) || !Number.isInteger(r) || n < 0 || r < 0 || r > n) throw new Error('Chalkboard.numb.permutation: Parameters "n" and "r" must be integers with 0 <= r <= n.');
             return Chalkboard.numb.factorial(n) / Chalkboard.numb.factorial(n - r);
         };
 
@@ -501,17 +703,12 @@ namespace Chalkboard {
          * const poissonRandom = Chalkboard.numb.Poissonian(0.5);
          */
         export const Poissonian = (l: number = 1): number => {
-            if (l > 0) {
-                const L = Chalkboard.E(-l);
-                let p = 1,
-                    k = 0;
-                for (; p > L; ++k) {
-                    p *= Math.random();
-                }
-                return k - 1;
-            } else {
-                return 0;
-            }
+            if (typeof l !== "number" || !Number.isFinite(l)) throw new Error('Chalkboard.numb.Poissonian: Parameter "l" must be a finite number.');
+            if (l <= 0) throw new Error('Chalkboard.numb.Poissonian: Parameter "l" must be positive.');
+            const L = Chalkboard.E(-l);
+            let p = 1, k = 0;
+            for (; p > L; ++k) p *= Math.random();
+            return k - 1;
         };
 
         /**
@@ -523,20 +720,17 @@ namespace Chalkboard {
          * const prime = Chalkboard.numb.prime(100);
          */
         export const prime = (num: number): number => {
-            if (num === 2) {
-                return 2;
-            }
-            let n = 1;
-            let prime = 3;
-            while (n < num) {
-                if (Chalkboard.numb.isPrime(prime)) {
-                    n++;
+            if (!Number.isInteger(num) || num < 1) throw new Error('Chalkboard.numb.prime: Parameter "num" must be a positive integer.');
+            if (num === 1) return 2;
+            let count = 1;
+            let p = 3;
+            while (true) {
+                if (Chalkboard.numb.isPrime(p)) {
+                    count++;
+                    if (count === num) return p;
                 }
-                if (n < num) {
-                    prime += 2;
-                }
+                p += 2;
             }
-            return prime;
         };
 
         /**
@@ -549,12 +743,10 @@ namespace Chalkboard {
          * const arr = Chalkboard.numb.primeArr(0, 1000);
          */
         export const primeArr = (inf: number, sup: number): number[] => {
-            const result = [];
-            for (let i = inf; i <= sup; i++) {
-                if (Chalkboard.numb.isPrime(i)) {
-                    result.push(i);
-                }
-            }
+            if (!Number.isInteger(inf) || !Number.isInteger(sup)) throw new Error('Chalkboard.numb.primeArr: Parameters "inf" and "sup" must be integers.');
+            if (inf > sup) throw new Error('Chalkboard.numb.primeArr: Parameter "inf" must be less than or equal to "sup".');
+            const result: number[] = [];
+            for (let i = inf; i <= sup; i++) if (Chalkboard.numb.isPrime(i)) result.push(i);
             return result;
         };
 
@@ -568,6 +760,8 @@ namespace Chalkboard {
          * const primes = Chalkboard.numb.primeCount(0, 1000);
          */
         export const primeCount = (inf: number, sup: number): number => {
+            if (!Number.isInteger(inf) || !Number.isInteger(sup)) throw new Error('Chalkboard.numb.primeCount: Parameters "inf" and "sup" must be integers.');
+            if (inf > sup) throw new Error('Chalkboard.numb.primeCount: Parameter "inf" must be less than or equal to "sup".');
             return Chalkboard.numb.primeArr(inf, sup).length;
         };
 
@@ -581,18 +775,16 @@ namespace Chalkboard {
          * const gap = Chalkboard.numb.primeGap(1, 100);
          */
         export const primeGap = (inf: number, sup: number): number => {
-            let prime = null;
+            if (!Number.isInteger(inf) || !Number.isInteger(sup)) throw new Error('Chalkboard.numb.primeGap: Parameters "inf" and "sup" must be integers.');
+            if (inf > sup) throw new Error('Chalkboard.numb.primeGap: Parameter "inf" must be less than or equal to "sup".');
+            let prime: number | null = null;
             let gap = 0;
-            for (let i = inf; i <= sup; i++) {
-                if (Chalkboard.numb.isPrime(i)) {
-                    if (prime !== null) {
-                        const temp = i - prime;
-                        if (temp > gap) {
-                            gap = temp;
-                        }
-                    }
-                    prime = i;
+            for (let i = inf; i <= sup; i++) if (Chalkboard.numb.isPrime(i)) {
+                if (prime !== null) {
+                    const temp = i - prime;
+                    if (temp > gap) gap = temp;
                 }
+                prime = i;
             }
             return gap;
         };
@@ -607,6 +799,8 @@ namespace Chalkboard {
          * const random = Chalkboard.numb.random(-1, 1);
          */
         export const random = (inf: number = 0, sup: number = 1): number => {
+            if (typeof inf !== "number" || typeof sup !== "number" || !Number.isFinite(inf) || !Number.isFinite(sup)) throw new Error('Chalkboard.numb.random: Parameters "inf" and "sup" must be finite numbers.');
+            if (inf > sup) throw new Error('Chalkboard.numb.random: Parameter "inf" must be less than or equal to "sup".');
             return inf + (sup - inf) * Math.random();
         };
 
@@ -620,26 +814,26 @@ namespace Chalkboard {
          * const rounded = Chalkboard.numb.roundTo(1237, 10);
          */
         export const roundTo = (num: number, positionalIndex: number): number => {
+            if (!Number.isFinite(num) || !Number.isFinite(positionalIndex)) throw new Error('Chalkboard.numb.roundTo: Parameters must be finite numbers.');
+            if (positionalIndex === 0) throw new Error('Chalkboard.numb.roundTo: Parameter "positionalIndex" must be non-zero.');
             return Math.round(num / positionalIndex) * positionalIndex;
         };
 
         /**
          * Returns the sign of a number.
          * @param {number} num - Number
-         * @returns {number}
+         * @returns {-1 | 0 | 1 | undefined}
          * @example
          * const pos = Chalkboard.numb.sgn(19); // Returns 1
          * const zero = Chalkboard.numb.sgn(0); // Returns 0
          * const neg = Chalkboard.numb.sgn(-5); // Returns -1
          */
-        export const sgn = (num: number): -1 | 0 | 1 => {
-            if (num > 0) {
-                return 1;
-            } else if (num < 0) {
-                return -1;
-            } else {
-                return 0;
-            }
+        export const sgn = (num: number): -1 | 0 | 1 | undefined => {
+            if (Number.isNaN(num)) return undefined;
+            if (!Number.isFinite(num)) throw new Error('Chalkboard.numb.sgn: Parameter "num" must be a finite number.');
+            if (num > 0) return 1;
+            else if (num < 0) return -1;
+            else return 0;
         };
 
         /**
@@ -653,10 +847,11 @@ namespace Chalkboard {
          * const sum = Chalkboard.numb.sum((n) => 1 / (n * n), 0, 1000);
          */
         export const sum = (formula: (n: number) => number, inf: number, sup: number): number => {
+            if (typeof formula !== "function") throw new Error('Chalkboard.numb.sum: Parameter "formula" must be a function.');
+            if (!Number.isInteger(inf) || !Number.isInteger(sup)) throw new Error('Chalkboard.numb.sum: Parameters "inf" and "sup" must be integers.');
+            if (inf > sup) throw new Error('Chalkboard.numb.sum: Parameter "inf" must be less than or equal to "sup".');
             let result = 0;
-            for (let i = inf; i <= sup; i++) {
-                result += formula(i);
-            }
+            for (let i = inf; i <= sup; i++) result += formula(i);
             return result;
         };
 
@@ -670,9 +865,10 @@ namespace Chalkboard {
          * const bin2 = Chalkboard.numb.toBinary(10, true); // Returns "0b1010"
          */
         export const toBinary = (num: number, prefix: boolean = false): string => {
-            if (!Number.isInteger(num)) throw new Error('Parameter "num" must be an integer.');
-            const result = Math.abs(num).toString(2);
-            return (prefix ? "0b" : "") + (num < 0 ? "-" : "") + result;
+            if (!Number.isInteger(num)) throw new Error('Chalkboard.numb.toBinary: Parameter "num" must be an integer.');
+            const sign = num < 0 ? "-" : "";
+            const digits = Math.abs(num).toString(2);
+            return sign + (prefix ? "0b" : "") + digits;
         };
 
         /**
@@ -686,20 +882,20 @@ namespace Chalkboard {
          * const dec3 = Chalkboard.numb.toDecimal("0x2a", 16); // Returns 42
          */
         export const toDecimal = (num: string, base: number): number => {
-            if (base < 2 || base > 36) throw new Error('Parameter "base" must be between 2 and 36.');
-            num = num.toLowerCase();
+            if (typeof num !== "string") throw new Error('Chalkboard.numb.toDecimal: Parameter "num" must be a string.');
+            if (!Number.isInteger(base) || base < 2 || base > 36) throw new Error('Chalkboard.numb.toDecimal: Parameter "base" must be an integer between 2 and 36.');
+            num = num.toLowerCase().trim();
+            const isNegative = num.startsWith("-");
+            if (isNegative) num = num.substring(1);
             if (base === 2 && num.startsWith("0b")) num = num.substring(2);
             if (base === 8 && num.startsWith("0o")) num = num.substring(2);
             if (base === 16 && num.startsWith("0x")) num = num.substring(2);
-            if (num.startsWith("-")) num = num.substring(1);
+            if (num.length === 0) throw new Error('Chalkboard.numb.toDecimal: Parameter "num" must contain digits.');
             const chars = "0123456789abcdefghijklmnopqrstuvwxyz".substring(0, base);
-            for (const char of num) {
-                if (!chars.includes(char)) {
-                    throw new Error(`Invalid character "${char}" for base ${base}.`);
-                }
-            }
+            for (const char of num) if (!chars.includes(char)) throw new Error(`Chalkboard.numb.toDecimal: Invalid character "${char}" for base ${base}.`);
             const result = parseInt(num, base);
-            return num.startsWith("-") ? -result : result;
+            if (!Number.isFinite(result)) throw new Error('Chalkboard.numb.toDecimal: Failed to parse "num".');
+            return isNegative ? -result : result;
         };
 
         /**
@@ -712,24 +908,40 @@ namespace Chalkboard {
          * const fraction = Chalkboard.numb.toFraction(-1.25);
          */
         export const toFraction = (num: number, tolerance: number = 1e-8): [number, number] => {
-            if (!isFinite(num)) throw new Error('The parameter "num" must be finite to be converted to a fraction.');
-            const sgn = Chalkboard.numb.sgn(num);
-            num *= sgn;
-            if (Number.isInteger(num)) return [sgn * num, 1];
+            if (typeof num !== "number" || typeof tolerance !== "number") throw new Error('Chalkboard.numb.toFraction: Parameters "num" and "tolerance" must be numbers.');
+            if (!Number.isFinite(num)) throw new Error('Chalkboard.numb.toFraction: The parameter "num" must be finite to be converted to a fraction.');
+            if (!Number.isFinite(tolerance) || tolerance <= 0) throw new Error('Chalkboard.numb.toFraction: The parameter "tolerance" must be a positive finite number.');
+            const sign = Chalkboard.numb.sgn(num);
+            if (sign === undefined) throw new Error('Chalkboard.numb.toFraction: The parameter "num" must be a valid number to be converted to a fraction.');
+            const x = Math.abs(num);
+            if (Number.isInteger(x)) return [sign * x, 1];
             let h1 = 1, h2 = 0, k1 = 0, k2 = 1;
-            let b = num;
-            while (true) {
-                let a = Math.floor(b);
-                let h = a * h1 + h2, k = a * k1 + k2;
-                let approx = h / k;
-                if (Math.abs(num - approx) < tolerance) {
+            let b = x;
+            const MAX_ITER = 10000;
+            for (let iter = 0; iter < MAX_ITER; iter++) {
+                const a = Math.floor(b);
+                const h = a * h1 + h2;
+                const k = a * k1 + k2;
+                if (k === 0) break;
+                const approx = h / k;
+                if (Math.abs(x - approx) < tolerance) {
                     const g = Chalkboard.numb.gcd(h, k);
-                    return [sgn * (h / g), k / g];
+                    return [sign * (h / g), k / g];
                 }
-                h2 = h1, h1 = h;
-                k2 = k1, k1 = k;
-                b = 1 / (b - a);
+                h2 = h1; h1 = h;
+                k2 = k1; k1 = k;
+                const frac = b - a;
+                if (Math.abs(frac) <= Number.EPSILON) {
+                    const g = Chalkboard.numb.gcd(h, k);
+                    return [sign * (h / g), k / g];
+                }
+                b = 1 / frac;
+                if (!Number.isFinite(b)) {
+                    const g = Chalkboard.numb.gcd(h, k);
+                    return [sign * (h / g), k / g];
+                }
             }
+            throw new Error('Chalkboard.numb.toFraction: Failed to converge to a fraction within the iteration limit.');
         };
 
         /**
@@ -743,10 +955,11 @@ namespace Chalkboard {
          * const hex2 = Chalkboard.numb.toHexadecimal(26, true, true); // Returns "0x1A"
          */
         export const toHexadecimal = (num: number, prefix: boolean = false, uppercase: boolean = false): string => {
-            if (!Number.isInteger(num)) throw new Error('The parameter "num" must be an integer.');
-            let result = Math.abs(num).toString(16);
-            if (uppercase) result = result.toUpperCase();
-            return (prefix ? "0x" : "") + (num < 0 ? "-" : "") + result;
+            if (!Number.isInteger(num)) throw new Error('Chalkboard.numb.toHexadecimal: The parameter "num" must be an integer.');
+            const sign = num < 0 ? "-" : "";
+            let digits = Math.abs(num).toString(16);
+            if (uppercase) digits = digits.toUpperCase();
+            return sign + (prefix ? "0x" : "") + digits;
         };
 
         /**
@@ -759,9 +972,10 @@ namespace Chalkboard {
          * const oct2 = Chalkboard.numb.toOctal(10, true); // Returns "0o12"
          */
         export const toOctal = (num: number, prefix: boolean = false): string => {
-            if (!Number.isInteger(num)) throw new Error('The parameter "num" must be an integer.');
-            const result = Math.abs(num).toString(8);
-            return (prefix ? "0o" : "") + (num < 0 ? "-" : "") + result;
+            if (!Number.isInteger(num)) throw new Error('Chalkboard.numb.toOctal: The parameter "num" must be an integer.');
+            const sign = num < 0 ? "-" : "";
+            const digits = Math.abs(num).toString(8);
+            return sign + (prefix ? "0o" : "") + digits;
         };
     }
 }

--- a/src/Chalkboard-plot.ts
+++ b/src/Chalkboard-plot.ts
@@ -21,7 +21,14 @@ namespace Chalkboard {
         /**
          * Plots the autocorrelation of an explicit function.
          * @param {ChalkboardFunction} func - The function
-         * @param {object} config - The configuration options
+         * @param {number} [config.x] - x-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.y] - y-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.size=1] - Scale, defaults to 1, divided by 100 internally for finer control
+         * @param {string} [config.strokeStyle="black"] - Stroke color
+         * @param {number} [config.lineWidth=2] - Stroke width
+         * @param {number[]} [config.domain=[-10, 10]] - Domain over which to plot (in units of the function, not pixels)
+         * @param {number} [config.res=25] - Resolution (distance in pixels between sampled points), higher values result in faster plotting but less smooth plots
+         * @param {CanvasRenderingContext2D} [config.context] - Optional custom canvas context to draw on
          * @returns {number[][]}
          */
         export const autocorrelation = (
@@ -64,9 +71,15 @@ namespace Chalkboard {
 
         /**
          * Plots a bar plot/chart/graph for an array of data with bins specified by another array.
-         * @param arr
-         * @param bins
-         * @param {object} config - The configuration options
+         * @param {number[]} arr - The data array
+         * @param {number[]} bins - The bins array (must be sorted in ascending order)
+         * @param {number} [config.x] - x-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.y] - y-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.size=1] - Scale, defaults to 1, divided by 100 internally for finer control
+         * @param {string} [config.fillStyle="white"] - Fill color for bars
+         * @param {string} [config.strokeStyle="black"] - Stroke color for bars
+         * @param {number} [config.lineWidth=2] - Stroke width for bars
+         * @param {CanvasRenderingContext2D} [config.context] - Optional custom canvas context to draw on
          * @returns {number[][]}
          */
         export const barplot = (
@@ -123,8 +136,13 @@ namespace Chalkboard {
 
         /**
          * Plots a complex number.
-         * @param comp
-         * @param {object} config - The configuration options
+         * @param {ChalkboardComplex} comp - The complex number
+         * @param {number} [config.x] - x-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.y] - y-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.size=1] - Scale, defaults to 1, divided by 100 internally for finer control
+         * @param {string} [config.fillStyle="black"] - Fill color for the complex number
+         * @param {number} [config.lineWidth=5] - Line width for the complex number
+         * @param {CanvasRenderingContext2D} [config.context] - Optional custom canvas context to draw on
          * @returns {number[][]}
          */
         export const comp = (
@@ -160,7 +178,14 @@ namespace Chalkboard {
          * Plots the convolution of two explicit functions.
          * @param {ChalkboardFunction} func1 - The first function
          * @param {ChalkboardFunction} func2 - The second function
-         * @param {object} config - The configuration options
+         * @param {number} [config.x] - x-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.y] - y-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.size=1] - Scale, defaults to 1, divided by 100 internally for finer control
+         * @param {string} [config.strokeStyle="black"] - Stroke color
+         * @param {number} [config.lineWidth=2] - Stroke width
+         * @param {number[]} [config.domain=[-10, 10]] - Domain over which to plot (in units of the function, not pixels)
+         * @param {number} [config.res=25] - Resolution (distance in pixels between sampled points), higher values result in faster plotting but less smooth plots
+         * @param {CanvasRenderingContext2D} [config.context] - Optional custom canvas context to draw on
          * @returns {number[][]}
          */
         export const convolution = (
@@ -206,7 +231,14 @@ namespace Chalkboard {
          * Plots the cross-correlation of two explicit functions.
          * @param {ChalkboardFunction} func1 - The first function
          * @param {ChalkboardFunction} func2 - The second function
-         * @param {object} config - The configuration options
+         * @param {number} [config.x] - x-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.y] - y-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.size=1] - Scale, defaults to 1, divided by 100 internally for finer control
+         * @param {string} [config.strokeStyle="black"] - Stroke color
+         * @param {number} [config.lineWidth=2] - Stroke width
+         * @param {number[]} [config.domain=[-10, 10]] - Domain over which to plot (in units of the function, not pixels)
+         * @param {number} [config.res=25] - Resolution (distance in pixels between sampled points), higher values result in faster plotting but less smooth plots
+         * @param {CanvasRenderingContext2D} [config.context] - Optional custom canvas context to draw on
          * @returns {number[][]}
          */
         export const correlation = (
@@ -251,7 +283,16 @@ namespace Chalkboard {
         /**
          * Plots a 2D scalar function, a parametric curve, or a complex function.
          * @param {ChalkboardFunction} func - The function
-         * @param {object} config - The configuration options
+         * @param {number} [config.x] - x-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.y] - y-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.size=1] - Scale, defaults to 1, divided by 100 internally for finer control
+         * @param {string} [config.strokeStyle="black"] - Stroke color
+         * @param {number} [config.lineWidth=2] - Stroke width
+         * @param {number[]} [config.domain=[-10, 10]] - Domain over which to plot (in units of the function, not pixels)
+         * @param {number} [config.res=25] - Resolution (distance in pixels between sampled points), higher values result in faster plotting but less smooth plots
+         * @param {boolean} [config.isInverse=false] - Whether to plot the inverse of the function (only for scalar2d)
+         * @param {boolean} [config.isPolar=false] - Whether to plot in polar coordinates (only for scalar2d)
+         * @param {CanvasRenderingContext2D} [config.context] - Optional custom canvas context to draw on
          * @returns {number[][]}
          */
         export const definition = (
@@ -341,7 +382,15 @@ namespace Chalkboard {
         /**
          * Plots the first-order derivative of an explicit or inverse function.
          * @param {ChalkboardFunction} func - The function
-         * @param {object} config - The configuration options
+         * @param {number} [config.x] - x-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.y] - y-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.size=1] - Scale, defaults to 1, divided by 100 internally for finer control
+         * @param {string} [config.strokeStyle="black"] - Stroke color
+         * @param {number} [config.lineWidth=2] - Stroke width
+         * @param {number[]} [config.domain=[-10, 10]] - Domain over which to plot (in units of the function, not pixels)
+         * @param {number} [config.res=25] - Resolution (distance in pixels between sampled points), higher values result in faster plotting but less smooth plots
+         * @param {boolean} [config.isInverse=false] - Whether to plot the derivative of the inverse of the function (only for scalar2d)
+         * @param {CanvasRenderingContext2D} [config.context] - Optional custom canvas context to draw on
          * @returns {number[][]}
          */
         export const dfdx = (
@@ -392,7 +441,15 @@ namespace Chalkboard {
         /**
          * Plots the second-order derivative of an explicit or inverse function.
          * @param {ChalkboardFunction} func - The function
-         * @param {object} config - The configuration options
+         * @param {number} [config.x] - x-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.y] - y-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.size=1] - Scale, defaults to 1, divided by 100 internally for finer control
+         * @param {string} [config.strokeStyle="black"] - Stroke color
+         * @param {number} [config.lineWidth=2] - Stroke width
+         * @param {number[]} [config.domain=[-10, 10]] - Domain over which to plot (in units of the function, not pixels)
+         * @param {number} [config.res=25] - Resolution (distance in pixels between sampled points), higher values result in faster plotting but less smooth plots
+         * @param {boolean} [config.isInverse=false] - Whether to plot the second derivative of the inverse of the function (only for scalar2d)
+         * @param {CanvasRenderingContext2D} [config.context] - Optional custom canvas context to draw on
          * @returns {number[][]}
          */
         export const d2fdx2 = (
@@ -443,7 +500,14 @@ namespace Chalkboard {
         /**
          * Plots a 2D vector field.
          * @param {ChalkboardFunction} vectfield
-         * @param {object} config - The configuration options
+         * @param {number} [config.x] - x-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.y] - y-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.size=1] - Scale, defaults to 1, divided by 100 internally for finer control
+         * @param {string} [config.strokeStyle="black"] - Stroke color
+         * @param {number} [config.lineWidth=2] - Stroke width
+         * @param {number[][]} [config.domain=[[-10, 10], [-10, 10]]] - Domain over which to plot (in units of the function, not pixels)
+         * @param {number} [config.res=25] - Resolution (distance in pixels between sampled points), higher values result in faster plotting but less smooth plots
+         * @param {CanvasRenderingContext2D} [config.context] - Optional custom canvas context to draw on
          * @returns {number[][]}
          */
         export const field = (
@@ -491,7 +555,14 @@ namespace Chalkboard {
         /**
          * Plots the Fourier transform of an explicit function.
          * @param {ChalkboardFunction} func - The function
-         * @param {object} config - The configuration options
+         * @param {number} [config.x] - x-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.y] - y-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.size=1] - Scale, defaults to 1, divided by 100 internally for finer control
+         * @param {string} [config.strokeStyle="black"] - Stroke color
+         * @param {number} [config.lineWidth=2] - Stroke width
+         * @param {number[]} [config.domain=[-10, 10]] - Domain over which to plot (in units of the function, not pixels)
+         * @param {number} [config.res=25] - Resolution (distance in pixels between sampled points), higher values result in faster plotting but less smooth plots
+         * @param {CanvasRenderingContext2D} [config.context] - Optional custom canvas context to draw on
          * @returns {number[][]}
          */
         export const Fourier = (
@@ -535,7 +606,15 @@ namespace Chalkboard {
         /**
          * Plots the antiderivative (or integral) of an explicit or inverse function.
          * @param {ChalkboardFunction} func - The function
-         * @param {object} config - The configuration options
+         * @param {number} [config.x] - x-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.y] - y-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.size=1] - Scale, defaults to 1, divided by 100 internally for finer control
+         * @param {string} [config.strokeStyle="black"] - Stroke color
+         * @param {number} [config.lineWidth=2] - Stroke width
+         * @param {number[]} [config.domain=[-10, 10]] - Domain over which to plot (in units of the function, not pixels)
+         * @param {number} [config.res=25] - Resolution (distance in pixels between sampled points), higher values result in faster plotting but less smooth plots
+         * @param {boolean} [config.isInverse=false] - Whether to plot the inverse function
+         * @param {CanvasRenderingContext2D} [config.context] - Optional custom canvas context to draw on
          * @returns {number[][]}
          */
         export const fxdx = (
@@ -586,7 +665,14 @@ namespace Chalkboard {
         /**
          * Plots the Laplace transform of an explicit function.
          * @param {ChalkboardFunction} func - The function
-         * @param {object} config - The configuration options
+         * @param {number} [config.x] - x-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.y] - y-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.size=1] - Scale, defaults to 1, divided by 100 internally for finer control
+         * @param {string} [config.strokeStyle="black"] - Stroke color
+         * @param {number} [config.lineWidth=2] - Stroke width
+         * @param {number[]} [config.domain=[-10, 10]] - Domain over which to plot (in units of the function, not pixels)
+         * @param {number} [config.res=25] - Resolution (distance in pixels between sampled points), higher values result in faster plotting but less smooth plots
+         * @param {CanvasRenderingContext2D} [config.context] - Optional custom canvas context to draw on
          * @returns {number[][]}
          */
         export const Laplace = (
@@ -636,9 +722,14 @@ namespace Chalkboard {
 
         /**
          * Plots a line chart/plot/graph for an array of data with bins specified by another array.
-         * @param arr
-         * @param bins
-         * @param {object} config - The configuration options
+         * @param {number[]} arr - The data array
+         * @param {number[]} bins - The bin edges array (length should be one more than the number of bins)
+         * @param {number} [config.x] - x-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.y] - y-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.size=1] - Scale, defaults to 1, divided by 100 internally for finer control
+         * @param {string} [config.strokeStyle="black"] - Stroke color
+         * @param {number} [config.lineWidth=2] - Stroke width
+         * @param {CanvasRenderingContext2D} [config.context] - Optional custom canvas context to draw on
          * @returns {number[][]}
          */
         export const lineplot = (
@@ -690,8 +781,14 @@ namespace Chalkboard {
 
         /**
          * Plots a 2x2 matrix.
-         * @param matr
-         * @param {object} config - The configuration options
+         * @param {ChalkboardMatrix} matr - The matrix
+         * @param {number} [config.x] - x-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.y] - y-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.size=1] - Scale, defaults to 1, divided by 100 internally for finer control
+         * @param {string} [config.strokeStyle="black"] - Stroke color
+         * @param {number} [config.lineWidth=2] - Stroke width
+         * @param {number[]} [config.domain=[-10, 10]] - Domain over which to plot (in units of the matrix, not pixels)
+         * @param {CanvasRenderingContext2D} [config.context] - Optional custom canvas context to draw on
          * @returns {number[][]}
          */
         export const matr = (
@@ -757,8 +854,98 @@ namespace Chalkboard {
         };
 
         /**
+         * Plots an ODE solution. Supports both scalar and system ODEs. For scalar ODEs, plots y(t). For systems, can plot either y[j] vs t or y[j] vs y[i] (phase plot) based on the "phase" config option.
+         * @param {{ t: number[]; y: number[][] }} sol - The solution object from Chalkboard.diff.solve or Chalkboard.diff.solveAdaptive
+         * @param {number} [config.x] - x-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.y] - y-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.size=1] - Scale, defaults to 1, divided by 100 internally for finer control
+         * @param {string} [config.strokeStyle="black"] - Stroke color
+         * @param {number} [config.lineWidth=2] - Stroke width
+         * @param {number} [config.i=0] - x-component index (for phase plots)
+         * @param {number} [config.j=1] - y-component index (for phase plots)
+         * @param {boolean} [config.phase=false] - If true, plots y[j] vs y[i] (phase plot), if false, plots y[i] vs t
+         * @param {CanvasRenderingContext2D} [config.context] - Canvas context
+         * @returns {number[][]}
+         * @example
+         * // Plot scalar solution y(t)
+         * const ode1 = Chalkboard.diff.exponential(-1);
+         * const sol1 = Chalkboard.diff.solve(ode1, { t0: 0, t1: 5, steps: 300, y0: 1 });
+         * Chalkboard.plot.ode(sol1, { strokeStyle: "red", size: 1 });
+         * 
+         * // Phase plot for harmonic oscillator (y vs dy)
+         * const ode2 = Chalkboard.diff.harmonic();
+         * const sol2 = Chalkboard.diff.solve(ode2, { t0: 0, t1: 20, steps: 2000, y0: { y0: 1, dy0: 0 } });
+         * Chalkboard.plot.ode(sol2, { phase: true, i: 0, j: 1, strokeStyle: "blue" });
+         */
+        export const ode = (
+            sol: { t: number[]; y: number[][] },
+            config: {
+                x?: number;
+                y?: number;
+                size?: number;
+                strokeStyle?: string;
+                lineWidth?: number;
+                i?: number;
+                j?: number;
+                phase?: boolean;
+                context?: CanvasRenderingContext2D;
+            } = {}
+        ): number[][] => {
+            ASSERT(sol && Array.isArray(sol.t) && Array.isArray(sol.y), `Chalkboard.plot.ode: Parameter "sol" must have properties "t" and "y" as arrays.`);
+            ASSERT(sol.t.length === sol.y.length && sol.t.length > 0, `Chalkboard.plot.ode: Invalid solution object (length mismatch or empty).`);
+            const ctx = config.context || getContext();
+            const x0 = (config.x ?? ctx.canvas.width / 2);
+            const y0 = (config.y ?? ctx.canvas.height / 2);
+            const strokeStyle = config.strokeStyle ?? "black";
+            const lineWidth = config.lineWidth ?? 2;
+            const size = ((config.size ?? 1) / 100);
+            const phase = config.phase ?? false;
+            const i = config.i ?? 0;
+            const j = config.j ?? 1;
+            const dim = sol.y[0].length;
+            ASSERT(Number.isInteger(i) && i >= 0, `Chalkboard.plot.ode: "i" must be an integer >= 0.`);
+            ASSERT(i < dim, `Chalkboard.plot.ode: "i" is out of range for solution dimension.`);
+            if (phase) {
+                ASSERT(Number.isInteger(j) && j >= 0, `Chalkboard.plot.ode: "j" must be an integer >= 0.`);
+                ASSERT(j < dim, `Chalkboard.plot.ode: "j" is out of range for solution dimension.`);
+                ASSERT(i !== j, `Chalkboard.plot.ode: For phase plots, "i" and "j" must be different.`);
+            }
+            const data: number[][] = [];
+            ctx.save();
+            ctx.translate(x0, y0);
+            ctx.lineWidth = lineWidth;
+            ctx.strokeStyle = strokeStyle;
+            ctx.beginPath();
+            if (!phase) {
+                for (let k = 0; k < sol.t.length; k++) {
+                    const X = sol.t[k] / size;
+                    const Y = -sol.y[k][i] / size;
+                    if (k === 0) ctx.moveTo(X, Y);
+                    else ctx.lineTo(X, Y);
+                    data.push([sol.t[k], sol.y[k][i]]);
+                }
+            } else {
+                for (let k = 0; k < sol.y.length; k++) {
+                    const X = sol.y[k][i] / size;
+                    const Y = -sol.y[k][j] / size;
+                    if (k === 0) ctx.moveTo(X, Y);
+                    else ctx.lineTo(X, Y);
+                    data.push([sol.y[k][i], sol.y[k][j]]);
+                }
+            }
+            ctx.stroke();
+            ctx.restore();
+            return data;
+        };
+
+        /**
          * Plots the polar coordinate plane.
-         * @param {object} config - The configuration options
+         * @param {number} [config.x] - x-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.y] - y-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.size=1] - Scale, defaults to 1, divided by 100 internally for finer control
+         * @param {string} [config.strokeStyle="black"] - Stroke color
+         * @param {number} [config.lineWidth=2] - Stroke width
+         * @param {CanvasRenderingContext2D} [config.context] - Optional custom canvas context to draw on
          * @returns {void}
          */
         export const rOplane = (config: {
@@ -801,9 +988,14 @@ namespace Chalkboard {
 
         /**
          * Plots a scatter plot of two arrays of data.
-         * @param arr1
-         * @param arr2
-         * @param {object} config - The configuration options
+         * @param {number[]} arr1 - The first data array (x-coordinates)
+         * @param {number[]} arr2 - The second data array (y-coordinates)
+         * @param {number} [config.x] - x-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.y] - y-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.size=1] - Scale, defaults to 1, divided by 100 internally for finer control
+         * @param {string} [config.fillStyle="black"] - Fill color for the points
+         * @param {number} [config.lineWidth=5] - Diameter of the points in pixels
+         * @param {CanvasRenderingContext2D} [config.context] - Optional custom canvas context to draw on
          * @returns {number[][]}
          */
         export const scatterplot = (
@@ -853,9 +1045,16 @@ namespace Chalkboard {
         /**
          * Plots the nth-degree Taylor series approximation for an explicit function.
          * @param {ChalkboardFunction} func - The function
-         * @param n
-         * @param a
-         * @param {object} config - The configuration options
+         * @param {0 | 1 | 2} n - The degree of the Taylor approximation (0 for constant, 1 for linear, 2 for quadratic)
+         * @param {number} a - The point of expansion (in units of the function, not pixels)
+         * @param {number} [config.x] - x-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.y] - y-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.size=1] - Scale, defaults to 1, divided by 100 internally for finer control
+         * @param {string} [config.strokeStyle="black"] - Stroke color
+         * @param {number} [config.lineWidth=2] - Stroke width
+         * @param {number[]} [config.domain=[-10, 10]] - Domain over which to plot (in units of the matrix, not pixels)
+         * @param {number} [config.res=25] - Resolution of the plot
+         * @param {CanvasRenderingContext2D} [config.context] - Optional custom canvas context to draw on
          * @returns {number[][]}
          */
         export const Taylor = (
@@ -900,8 +1099,13 @@ namespace Chalkboard {
 
         /**
          * Plots a 2D vector.
-         * @param vect
-         * @param {object} config - The configuration options
+         * @param {ChalkboardVector} vect - The vector
+         * @param {number} [config.x] - x-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.y] - y-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.size=1] - Scale, defaults to 1, divided by 100 internally for finer control
+         * @param {string} [config.strokeStyle="black"] - Stroke color
+         * @param {number} [config.lineWidth=5] - Stroke width
+         * @param {CanvasRenderingContext2D} [config.context] - Optional custom canvas context to draw on
          * @returns {number[][]}
          */
         export const vect = (
@@ -938,7 +1142,12 @@ namespace Chalkboard {
 
         /**
          * Plots the Cartesian coordinate plane.
-         * @param {object} config - The configuration options
+         * @param {number} [config.x] - x-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.y] - y-offset (canvas translation), defaults to canvas center
+         * @param {number} [config.size=1] - Scale, defaults to 1, divided by 100 internally for finer control
+         * @param {string} [config.strokeStyle="black"] - Stroke color
+         * @param {number} [config.lineWidth=2] - Stroke width
+         * @param {CanvasRenderingContext2D} [config.context] - Optional custom canvas context to draw on
          * @returns {void}
          */
         export const xyplane = (config: {

--- a/src/Chalkboard-real.ts
+++ b/src/Chalkboard-real.ts
@@ -438,24 +438,11 @@ namespace Chalkboard {
                         i++;
                         continue;
                     }
-                    if ("+-*/(),".indexOf(ch) !== -1) {
+                    if ("+-*/(),^".indexOf(ch) !== -1) {
                         tokens.push(ch);
                         i++;
-                        if (ch === ")" && i < input.length && (/[a-zA-Z0-9_(]/.test(input[i]))) tokens.push("*");
-                    } else if (ch === "^") {
-                        tokens.push(ch);
-                        i++;
-                        if (i < input.length && input[i] === "-") {
-                            let num = "-";
-                            i++;
-                            while (i < input.length && /[0-9.]/.test(input[i])) {
-                                num += input[i++];
-                            }
-                            if (num !== "-") {
-                                tokens.push(num);
-                            } else {
-                                tokens.push("-");
-                            }
+                        if (ch === ")" && i < input.length && (/[a-zA-Z0-9_(]/.test(input[i]))) {
+                            if (tokens[tokens.length - 1] !== "*") tokens.push("*");
                         }
                     } else if (/[0-9]/.test(ch) || (ch === "." && /[0-9]/.test(input[i + 1]))) {
                         let num = "";
@@ -465,19 +452,28 @@ namespace Chalkboard {
                             num += input[i++];
                         }
                         tokens.push(num);
-                        if (i < input.length && (/[a-zA-Z_(]/.test(input[i]))) tokens.push("*");
+                        if (i < input.length && (/[a-zA-Z_(]/.test(input[i]))) {
+                            if (tokens[tokens.length - 1] !== "*") tokens.push("*");
+                        }
                     } else if (/[a-zA-Z_]/.test(ch)) {
                         let name = "";
                         while (i < input.length && /[a-zA-Z0-9_]/.test(input[i])) {
                             name += input[i++];
                         }
-                        tokens.push(name);
+                        if (/^[a-zA-Z]+$/.test(name) && name.length > 1 && !isFunction(name)) {
+                            for (let j = 0; j < name.length; j++) {
+                                tokens.push(name[j]);
+                                if (j < name.length - 1) tokens.push("*");
+                            }
+                        } else {
+                            tokens.push(name);
+                        }
                         if (i < input.length && input[i] === "(") {
                             if (!isFunction(name)) {
-                                tokens.push("*");
+                                if (tokens[tokens.length - 1] !== "*") tokens.push("*");
                             }
                         } else if (i < input.length && (/[a-zA-Z_]/.test(input[i]))) {
-                            tokens.push("*");
+                            if (tokens[tokens.length - 1] !== "*") tokens.push("*");
                         }
                     } else {
                         throw new Error(`Chalkboard.real.parse: Unexpected character ${ch}`);
@@ -525,10 +521,15 @@ namespace Chalkboard {
                     let node = parsePrimary();
                     if (peek() === "^") {
                         consume("^");
-                        const right = parseExponent(); 
+                        const right = parseExponentUnary();
                         node = { type: "pow", base: node, exponent: right };
                     }
                     return node;
+                };
+                const parseExponentUnary = (): { type: string, [key: string]: any } => {
+                    if (peek() === "-") { consume("-"); return { type:"neg", expr: parseExponentUnary() }; }
+                    if (peek() === "+") { consume("+"); return parseExponentUnary(); }
+                    return parseExponent();
                 };
                 const parsePrimary = (): { type: string, [key: string]: any } => {
                     const token = peek();
@@ -573,18 +574,6 @@ namespace Chalkboard {
                     case "var": {
                         const varname = node.name;
                         if (varname in values) return values[varname];
-                        for (let i = 1; i < varname.length; i++) {
-                            const left = varname.substring(0, i);
-                            const right = varname.substring(i);
-                            if (left in values) {
-                                try {
-                                    const rightResult = evaluateNode({ type: "var", name: right }, values);
-                                    return values[left] * rightResult;
-                                } catch {
-                                    continue;
-                                }
-                            }
-                        }
                         throw new Error(`Chalkboard.real.parse: Variable '${varname}' not defined in values`);
                     }
                     case "add": {
@@ -638,20 +627,32 @@ namespace Chalkboard {
                         return node.name;
                     }
                     case "add": {
+                        if (node.right.type === "mul" && node.right.left?.type === "num" && node.right.left.value === -1 && node.right.right?.type === "neg") return `${nodeToString(node.left)} + ${nodeToString(node.right.right.expr)}`;
                         if (node.right.type === "num" && node.right.value < 0) return `${nodeToString(node.left)} - ${nodeToString({ type: "num", value: -node.right.value })}`;
                         if (node.right.type === "neg") return `${nodeToString(node.left)} - ${nodeToString(node.right.expr)}`;
                         if (node.right.type === "mul" && node.right.left.type === "num" && node.right.left.value < 0) return `${nodeToString(node.left)} - ${nodeToString({ type: "mul", left: { type: "num", value: -node.right.left.value }, right: node.right.right })}`;
+                        if (node.right.type === "mul" && node.right.right.type === "num" && node.right.right.value < 0) return `${nodeToString(node.left)} - ${nodeToString({ type: "mul", left: node.right.left, right: { type: "num", value: -node.right.right.value }})}`;
+                        if (nodeToString(node.right).startsWith("-")) return `${nodeToString(node.left)} - ${nodeToString(node.right).slice(1)}`;
                         return `${nodeToString(node.left)} + ${nodeToString(node.right)}`;
                     }
                     case "sub": {
-                        const rightStr = node.right.type === "add" || node.right.type === "sub" ?`(${nodeToString(node.right)})` : nodeToString(node.right);
+                        if (node.right.type === "neg") return `${nodeToString(node.left)} + ${nodeToString(node.right.expr)}`;
+                        if (node.right.type === "mul" && node.right.left?.type === "num" && node.right.left.value === 1 && node.right.right?.type === "neg") return `${nodeToString(node.left)} + ${nodeToString(node.right.right.expr)}`;
+                        if (node.right.type === "mul" && node.right.left?.type === "num" && node.right.left.value === -1) return `${nodeToString(node.left)} + ${nodeToString(node.right.right)}`;
+                        if (node.right.type === "mul" && node.right.left?.type === "num" && node.right.left.value === 1 && node.right.right?.type === "mul" && node.right.right.left?.type === "num" && node.right.right.left.value === -1) return `${nodeToString(node.left)} + ${nodeToString(node.right.right.right)}`;
+                        const rightStr = (node.right.type === "add" || node.right.type === "sub") ? `(${nodeToString(node.right)})` : nodeToString(node.right);
                         return `${nodeToString(node.left)} - ${rightStr}`;
                     }
                     case "mul": {
+                        if (node.left.type === "num" && node.left.value === 1) return nodeToString(node.right);
+                        if (node.right.type === "num" && node.right.value === 1) return nodeToString(node.left);
                         if (node.left.type === "num" && node.left.value === -1 && node.right.type === "var") return `-${nodeToString(node.right)}`;
+                        if (node.left.type === "num" && node.left.value === -1 && node.right.type === "pow") return `-${nodeToString(node.right)}`;
                         if (node.left.type === "num" && (node.right.type === "var" || node.right.type === "pow")) return `${nodeToString(node.left)}${nodeToString(node.right)}`;
+                        if (node.left.type === "pow" && node.right.type === "pow") return `${nodeToString(node.left)}${nodeToString(node.right)}`;
+                        if (node.left.type === "pow" && node.right.type === "var") return `${nodeToString(node.left)}${nodeToString(node.right)}`;
+                        if (node.left.type === "var" && node.right.type === "pow") return `${nodeToString(node.left)}${nodeToString(node.right)}`;
                         if (node.left.type === "var" && node.right.type === "var") return `${nodeToString(node.left)}${nodeToString(node.right)}`;
-                        if (node.left.type === "mul" && ((node.left.left.type === "num" || node.left.right.type === "var" || node.left.right.type === "pow") || (node.left.right.type === "var" || node.left.right.type === "pow")) && (node.right.type === "var" || node.right.type === "pow")) return `${nodeToString(node.left)}${nodeToString(node.right)}`;
                         return `${nodeToString(node.left)} * ${nodeToString(node.right)}`;
                     }
                     case "div": {
@@ -666,6 +667,7 @@ namespace Chalkboard {
                     }
                     case "neg": {
                         if (node.expr.type === "add" || node.expr.type === "sub") return `-(${ nodeToString(node.expr) })`;
+                        if (node.expr.type === "pow") return `-${nodeToString(node.expr)}`;
                         const exprStr = (node.expr.type !== "num" && node.expr.type !== "var") ? `(${ nodeToString(node.expr) })` : nodeToString(node.expr);
                         return `-${ exprStr }`;
                     }
@@ -684,13 +686,25 @@ namespace Chalkboard {
                         return node.name;
                     }
                     case "add": {
+                        if (nodeToLaTeX(node.right).startsWith("-")) return `${nodeToLaTeX(node.left)} - ${nodeToLaTeX(node.right).slice(1)}`;
                         return `${nodeToLaTeX(node.left)} + ${nodeToLaTeX(node.right)}`;
                     }
                     case "sub": {
-                        return `${nodeToLaTeX(node.left)} - ${nodeToLaTeX(node.right)}`;
+                        const right = nodeToLaTeX(node.right);
+                        if (right.startsWith("-")) return `${nodeToLaTeX(node.left)} + ${right.slice(1)}`;
+                        return `${nodeToLaTeX(node.left)} - ${right}`;
                     }
                     case "mul": {
-                        return `${nodeToLaTeX(node.left)}${nodeToLaTeX(node.right)}`;
+                        const isAtomicLaTeX = (n: any): boolean => n.type === "num" || n.type === "var" || n.type === "pow" || n.type === "func";
+                        const wrapIfNeeded = (n: any): string => {
+                            const s = nodeToLaTeX(n);
+                            if (n.type === "add" || n.type === "sub") return `\\left(${s}\\right)`;
+                            return s;
+                        };
+                        const left = wrapIfNeeded(node.left);
+                        const right = wrapIfNeeded(node.right);
+                        if (isAtomicLaTeX(node.left) && isAtomicLaTeX(node.right)) return `${left}${right}`;
+                        return `${left} \\cdot ${right}`;
                     }
                     case "div": {
                         return `\\frac{${nodeToLaTeX(node.left)}}{${nodeToLaTeX(node.right)}}`;

--- a/src/Chalkboard-stat.ts
+++ b/src/Chalkboard-stat.ts
@@ -243,7 +243,7 @@ namespace Chalkboard {
          */
         export const cummul = (arr: number[]): number[] => {
             const result = [];
-            let mul = 0;
+            let mul = 1;
             for (let i = 0; i < arr.length; i++) {
                 mul *= arr[i];
                 result.push(mul);
@@ -757,7 +757,7 @@ namespace Chalkboard {
          * @returns {number}
          */
         export const mul = (arr: number[]): number => {
-            let result = 0;
+            let result = 1;
             for (let i = 0; i < arr.length; i++) {
                 result *= arr[i];
             }

--- a/src/Chalkboard.ts
+++ b/src/Chalkboard.ts
@@ -48,6 +48,20 @@ type ChalkboardMorphism<T, U> = {
 };
 
 /**
+ * The type for ordinary differential equations.
+ * @property {(t: number, y: number[]) => number[]} rule - Canonical first-order system rule: y' = F(t, y)
+ * @property {number} order - Original order of equation if constructed from scalar, else 1 for systems
+ * @property {number} dimension - Dimension of canonical state vector y
+ * @property {"single" | "system"} type - "single" for scalar input rules (order 1 or 2), "system" for user-supplied systems
+ */
+type ChalkboardODE = {
+    rule: (t: number, y: number[]) => number[];
+    order: number;
+    dimension: number;
+    type: "single" | "system";
+};
+
+/**
  * The type for quaternions.
  * @property {number} a - The real part
  * @property {number} b - The first imaginary part
@@ -226,6 +240,11 @@ namespace Chalkboard {
             }
         }
         throw new TypeError('Chalkboard.APPLY can only operate on a "ChalkboardComplex", "ChalkboardMatrix", "ChalkboardQuaternion", "ChalkboardTensor", "ChalkboardVector", "ChalkboardSet", or "ChalkboardStructure".');
+    };
+
+    /** @ignore */
+    export const ASSERT = (cond: any, msg: string): void => {
+        if (!cond) throw new Error(msg);
     };
 
     /**


### PR DESCRIPTION
Added the `diff` category which has 35 new commands for defining, solving, and analyzing ordinary differential equations, as well as 1 new command in the `plot` category for plotting their solutions. Here is a brief example of some of the new functionalities:
```js
const cb = Chalkboard;
const f = cb.diff.harmonic(cb.PI(2)); // Defines harmonic oscillator y'' = -4π²y
const sol = cb.diff.solveAdaptive(f, { t0: 0, t1: 2, y0: { y0: 1, dy0: 0 }, h0: 0.01, hMin: 1e-6, hMax: 0.05 }); // Solves with adaptive Dormand–Prince RK45
const samples = cb.diff.sample(sol, [0, 0.25, 0.5, 0.75, 1.0]); // Samples solution at specified times
const phase = cb.diff.phase(sol, 0, 1); // Produces (y, dy) pairs for a phase plot
const err = cb.diff.error(sol, f, "LInfinity"); // Computes residual error (infinity norm) of the solution
cb.plot.ode(sol, { phase: true, i: 0, j: 1 }); // Plots the phase portrait (y vs dy) on the canvas
```
Furthermore, `numb.convert` was added, which can be used for conversions between various different units of measurements:
```js
const cb = Chalkboard;
const m = cb.numb.convert(1500, "mm", "m"); // Length conversion
const sqmi = cb.numb.convert(1000000, "m2", "mi2"); // Area conversion
const kg = cb.numb.convert(5000, "g", "kg"); // Mass conversion
const ml = cb.numb.convert(3, "gal", "mL"); // Volume conversion
const pa = cb.numb.convert(1, "atm", "Pa"); // Pressure conversion
const ns = cb.numb.convert(2, "hr", "ns"); // Time conversion
const k = cb.numb.convert(98.6, "F", "K"); // Temperature conversion
```
Also there is now an `ASSERT` command, which is currently used throughout the `diff` and `numb` categories for rigorous error-checking, and is planned to be expanded for usage throughout all of the categories for the full release of Chalkboard v3.0.0.
Besides these new features, a bunch of miscellaneous changes have also been implemented.
Firstly, the `real.parse`, `comp.parse`, and `bool.parse` commands were changed such that tokenization was made more robust (implicit multiplication and splitting of non-function multi-letter identifiers into single-letter multiplicative tokens is done at tokenize time), exponent parsing/unary-sign handling was improved, the evaluator no longer performs ad hoc variable concatenation, and the AST simplification/string/LaTeX output was tightened.
Secondly, fixed `numb.compositeArr` to not treat 0 and 1 as composites, fixed `numb.Fibonacci` by replacing the recursive implementation with an iterative implementation, fixed `numb.Gaussian` so that it uses a standard Box-Muller transform and applies the mean and standard deviation correctly (removed the ambiguous "height" parameter), fixed `numb.Euler` to correctly use distinct prime factors, fixed `numb.gcd` and `numb.lcm` to use absolute values, fixed `numb.toDecimal` to preserve the original sign of a number, fixed `numb.prime` to handle small indices correctly, fixed `numb.map` to avoid division by zero, and fixed `numb.toFraction` to have an iteration maximum.
Thirdly, fixed `stat.mul` and `stat.cummul` so that they no longer always return 0.
Fourthly, the file of the `matr` category was reformatted to be 735 lines (17 kB) smaller.
Similar to the previous updates (#6, #7) contributing to v3.0.0, this update is notably beneficial as it significantly enhances the functionality of a core aspect of Chalkboard, and in general, continues to establish it as a robust, extensible, and modern math engine for both users and developers.